### PR TITLE
use-case : Add MWI CI CD example with Github

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,7 @@ Documentation‑only assets: how‑tos, design notes, architecture diagrams, and
 - Prefer Markdown; include images/diagrams in `docs/img/`, or better yet using ```mermaid
 - Link back to the related use‑case/PoC/template when relevant.
 - Keep examples sanitized; no secrets or customer identifiers.
+
+## Use Cases
+
+- [MWI](mwi/mwi.md)

--- a/templates/teleport/README.md
+++ b/templates/teleport/README.md
@@ -1,0 +1,5 @@
+# Teleport Templates
+
+- [bots](bots)
+- [roles](roles) 
+- [tokens](tokens/)

--- a/templates/teleport/bots/database-tunnel-bot.yaml
+++ b/templates/teleport/bots/database-tunnel-bot.yaml
@@ -1,0 +1,10 @@
+kind: bot
+version: v1
+metadata:
+  # name is a unique identifier for the Bot in the cluster.
+  name:  github-action-db-tunnel-example-bot
+spec:
+  # roles is a list of roles to grant to the Bot. Don't worry if you don't know
+  # what roles you need to specify here, the Access Guides will walk you through
+  # creating and assigning roles to the already created Bot.
+  roles: ["dev-db-tunnel-role"]

--- a/templates/teleport/roles/database-tunnel-role.yaml
+++ b/templates/teleport/roles/database-tunnel-role.yaml
@@ -1,0 +1,41 @@
+kind: role
+metadata:
+  description: Allow Database Tunnels to all dev dbs
+  labels:
+    resource-type: database
+  name: dev-db-tunnel-role
+spec:
+  allow:
+    db_labels:
+      env: dev
+    db_names:
+    - '{{internal.db_names}}'
+    - transactionsDb
+    db_roles:
+    - '{{internal.db_roles}}'
+    db_service_labels:
+      env: dev
+    db_users:
+    - '{{internal.db_users}}'
+    - teleport-db-admin
+  deny: {}
+  options:
+    cert_format: standard
+    create_db_user: false
+    create_desktop_user: false
+    desktop_clipboard: true
+    desktop_directory_sharing: true
+    enhanced_recording:
+    - command
+    - network
+    forward_agent: false
+    idp:
+      saml:
+        enabled: true
+    max_session_ttl: 1h0m0s
+    pin_source_ip: false
+    record_session:
+      default: best_effort
+      desktop: true
+    ssh_file_copy: false
+version: v7

--- a/templates/teleport/tokens/database-tunnel-bot-token.yaml
+++ b/templates/teleport/tokens/database-tunnel-bot-token.yaml
@@ -1,0 +1,18 @@
+kind: token
+version: v2
+metadata:
+  name: github-action-db-tunnel-example-token
+spec:
+  # The Bot role indicates that this token grants access to a bot user, rather
+  # than allowing a node to join. This role is built in to Teleport.
+  roles: [Bot]
+  join_method: github
+  # The bot_name indicates which bot user this token grants access to. This
+  # should match the name of the bot that you created in the previous step.
+  bot_name: github-action-db-tunnel-example-bot
+  github:
+    # allow specifies rules that control which GitHub Actions runs will be
+    # granted access. Those not matching any allow rule will be denied.
+    allow:
+    # repository should include the name of the owner of the repository.
+    - repository: gravitational/rev-tech

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -1,3 +1,7 @@
 # use-cases
 
 Sanitized, customer‑agnostic patterns that explain **what to build** and **why**.
+
+## Examples
+
+- [MWI](mwi/README.md)

--- a/use-cases/mwi/README.md
+++ b/use-cases/mwi/README.md
@@ -1,0 +1,11 @@
+# MWI (Machine & Workload Identity)
+
+## Key Concepts and Technologies
+
+*   **Teleport's Ephemeral Certificates**: The repository demonstrates Teleport's ability to **issue ephemeral certificates using Machine and Workload Identity**. This approach provides short-lived credentials for access, greatly reducing the attack surface associated with long-lived static secrets.
+*   **`tbot` for Local Database Tunnels**: A central aspect of this example is the use of `tbot`. Tbot enables secure connectivity to databases without directly exposing them or embedding sensitive credentials in CI/CD pipelines or local configurations.
+*   **Simplified CI/CD Journey**: By utilizing Teleport's identity-based access and ephemeral certificates, the process of logging in and accessing resources within the CI/CD pipeline becomes more secure and less complex, **minimizing secrets** that need to be managed.
+
+## Examples
+
+- [Github](ci-cd/github/README.md)

--- a/use-cases/mwi/ci-cd/github/README.md
+++ b/use-cases/mwi/ci-cd/github/README.md
@@ -1,0 +1,19 @@
+# Github
+
+## MWI
+- [Database Tunnel Workflow](mwi-database-tunnel.yaml): An example demonstrating the use of Teleport for secure database tunneling, streamlining CI/CD workflows, and enhancing secret management
+    - Prequisites
+        The proper role to create resources within your Teleport Cluster: (`access`, `editor` )
+
+    - Getting Started
+
+        Download each of the files below and create the resources using `tctl create -f FILE-NAME-HERE.yaml`    
+
+        - [Database Tunnel Bot](/templates/teleport/bots/database-tunnel-bot.yaml) - bot has scoped permissions to start a database tunnel
+        - [Database Tunnel Role](/templates/teleport/roles/database-tunnel-role.yaml) - defines access to Teleport Protected Databaseses
+        - [Database Tunnel Bot Token](/templates/teleport/tokens/database-tunnel-bot-token.yaml) - CI/CD pipeline token
+
+    - Create a workflow in Github using the [following](mwi-database-tunnel.yaml) as reference
+
+    - Reference
+        - [Teleport Github actions](https://goteleport.com/docs/machine-workload-identity/machine-id/deployment/github-actions/)

--- a/use-cases/mwi/ci-cd/github/mwi-database-tunnel.yaml
+++ b/use-cases/mwi/ci-cd/github/mwi-database-tunnel.yaml
@@ -1,0 +1,80 @@
+name: tbot Database Tunnel Example
+
+on:
+  push: {}
+  workflow_dispatch: {}
+  pull_request:
+
+jobs:
+  tbotDbTunnelExample:
+    name: Teleport tbot Database Tunnel Example
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      actions: read
+      contents: read  # Access to the repository contents (e.g., checkouts, fetching)
+      pull-requests: write  # If the CD pipeline interacts with PRs
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Set Variables
+        id: version
+        run: |
+          echo "TELEPORT_CLUSTER_VERSION=$(curl https://${{ secrets.TELEPORT_CLUSTER_DOMAIN }}/v1/webapi/automaticupgrades/channel/default/version | sed 's/v//')" >> $GITHUB_ENV
+
+      - name: Fetch Teleport binaries
+        uses: teleport-actions/setup@v1
+        with:
+          version: ${{ env.TELEPORT_CLUSTER_VERSION }}
+
+      - name: Start Database Tunnel Bot
+        run: |
+          cat <<EOF > /tmp/bot-config.yaml
+          version: v2
+          onboarding:
+            join_method: github
+            token: ${{ secrets.TELEPORT_BOT_TOKEN }}
+          storage:
+            type: directory
+            path: /tmp/tbot
+            symlinks: try-secure
+            acls: "off"
+          services:
+            - type: database-tunnel
+              listen: tcp://127.0.0.1:5432
+              service: dev-psql-rds
+              database: transactionsDb
+              username: teleport-db-admin
+          debug: false
+          proxy_server: ${{ secrets.TELEPORT_CLUSTER_DOMAIN }}:443
+          oneshot: false
+          fips: false
+          EOF
+          
+          export TELEPORT_ANONYMOUS_TELEMETRY=1 
+          nohup tbot start -c /tmp/bot-config.yaml  --certificate-ttl 10m --renewal-interval 5m &
+          # Write tbot PID to file
+          echo $! > /tmp/tbot.pid
+
+      - name: Exec Database Query (Retry for 5 minutes)
+        run: |
+          end=$((SECONDS+300))
+          while [ $SECONDS -lt $end ]; do
+            psql -h 127.0.0.1 -U teleport-db-admin -p 5432 -d transactionsDb -c "SELECT version();" || true
+            sleep 5
+          done
+
+      - name: Clean up
+        if: always()
+        run: |
+          if [[ -f /tmp/tbot.pid ]]; then
+            echo "Killing tbot with PID $(cat /tmp/tbot.pid)"
+            kill "$(cat /tmp/tbot.pid)" || true
+            rm -f /tmp/tbot.pid
+          fi
+          rm -rf /tmp/tbot /tmp/bot-config.yaml /tmp/tbot.log


### PR DESCRIPTION
## Summary
CI/CD example of a database tunnel opened via MWI (tbot)

## What changed
- Docs (MWI)
- Templates (roles, bot, tokens)

## How to test
- tctl create -f <role> <bot> <token>`

## Checklist
- [ ✅ ] README included
- [ ✅ ] .env.example (no secrets)
- [ ✅ ] Requested reviews
