### PR TITLE
feat(teleport-api-scripts): align MAU/TPR reports to Teleport billing cycles

### DIFF
--- a/tools/teleport-api-scripts/CLAUDE.md
+++ b/tools/teleport-api-scripts/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+Two standalone Go programs for investigative reporting against a Teleport cluster's audit log and resource APIs. Output is intended for capacity planning and ballpark billing checks — **not** an authoritative source for license counts (see disclaimer in `MAU_README.md` / `TPR_README.md`).
+
+- `mau.go` — one-shot Monthly Active Users report (Zero Trust Access + Identity Governance) over the last N days of audit events.
+- `tpr.go` — long-lived service that polls Teleport for Protected Resources and Machine & Workload Identity counts, persists history to SQLite, and re-emits a report each interval.
+
+Both share the same `package main` and the same `go.mod` (module name `teleport-mau`), but are compiled and run independently — there is no shared library code. They are co-located only because they share the `run.sh` launcher.
+
+## How to build and run
+
+The expected entrypoint for end users is `run.sh`, which:
+1. Probes `https://<proxy>/v1/webapi/find` for `server_version`.
+2. Resolves that tag to a commit SHA on `github.com/gravitational/teleport` and runs `go get github.com/gravitational/teleport/api@<sha>` + `go mod tidy` so the API client version matches the cluster.
+3. Runs `go run mau.go` and/or `go run tpr.go` against the proxy.
+
+This means **the version pin in `go.mod` for `github.com/gravitational/teleport/api` is expected to drift** depending on which cluster was last targeted — don't treat changes to that pin as meaningful unless you're updating it deliberately.
+
+Common invocations:
+
+```bash
+# MAU report (uses current tsh login)
+bash ./run.sh -p teleport.example.com:443 -m
+
+# TPR tracker with identity file (recommended for long-running)
+bash ./run.sh -p teleport.example.com:443 -i /path/to/identity -t
+
+# Build standalone binaries (TPR needs CGO for sqlite)
+go build -o teleport-mau-tracker mau.go
+CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o teleport-tpr-tracker tpr.go
+```
+
+`run.sh` requires `curl`, `go`, `git`, `jq`, `tsh` on PATH. There is no test suite and no linter wired up.
+
+## Architecture notes worth knowing before editing
+
+**Authentication.** Both programs use `github.com/gravitational/teleport/api/client`. They fall back to the local `tsh` profile by default; pass `-identity_file` to use an exported identity instead. `run.sh` validates the tsh profile's `valid_until` before launching and refuses to run with an expired profile.
+
+**MAU (`mau.go`) data flow.** Pulls audit events in batches of `batchSize` (default 5000) via the events API, classifies each event into either a ZTA resource-access bucket (SSH / Kube / DB / App / Desktop) or an IG governance bucket (access requests, access lists, SAML IdP). A user can appear in both ZTA and IG totals — that's by design, not a double-count bug. `classifyUserKind` inspects the raw event's `user_kind` field to label bot vs. human in the text report; the field is sometimes a string ("bot"/"human"/"USER_KIND_BOT") and sometimes a numeric enum, and both shapes are handled.
+
+**TPR (`tpr.go`) data flow.** Maintains in-memory maps (`resources`, `botInstances`) protected by `resourcesMutex`, persists rolling counts to `teleport_usage_data.db` (SQLite, hence the CGO requirement), and trims rows older than `dataRetentionDays`. Each `updateInterval` tick: re-lists all resource kinds from the API, watches for `instance.join` / `bot.join` events since the last tick, evicts stale entries, then writes a fresh `Teleport_Usage_Report.{txt,json}`. SPIFFE ID issuance is counted *per period* (not cumulative), so the value resets each interval.
+
+**Config style.** Tunables live as `var (...)` blocks at the top of each file (e.g. `daysBack`, `batchSize`, `updateInterval`, `dataRetentionDays`). The READMEs instruct users to edit these directly rather than expose them as flags — only `-proxy`, `-identity_file`, and `-format` are flags. Keep that convention if adding new knobs unless the user specifically wants a flag.
+
+**Minimum Teleport role** for each script is documented inline in the respective README — MAU needs `event` read; TPR additionally needs label-wildcard read on app/db/kube/node/windows_desktop.
+
+## Output artifacts (gitignored in practice, present in working tree)
+
+- `Teleport_Active_Users.{txt,json}` — MAU report.
+- `Teleport_Usage_Report.{txt,json}` — TPR report (overwritten each interval).
+- `teleport_usage_data.db` — TPR SQLite history.
+- `teleport_tracker.log` — TPR runtime log.
+- `teleport-{mau,tpr}-tracker-*` — built binaries.
+
+These are produced by running the scripts and shouldn't be committed.

--- a/tools/teleport-api-scripts/MAU_README.md
+++ b/tools/teleport-api-scripts/MAU_README.md
@@ -59,6 +59,36 @@ daysBack = 60  // Default is 30 days back
 batchSize = 10000  // Increase batch size for better performance. Default is 5000
 ```
 
+## Billing Cycles
+
+Teleport bills against monthly cycles anchored to a customer-specific day, not the
+1st of each month. To produce a report that lines up with the "Usage History" view
+in Teleport Cloud, pass `-billing-day` with your anchor day (1-31):
+
+```bash
+# Aligned to cycles starting on the 7th of each month (e.g. 7 May - 6 Jun)
+bash ./run.sh -p teleport.example.com:443 -m -b 7
+
+# Include 5 completed cycles in addition to the in-progress one (default: 3)
+bash ./run.sh -p teleport.example.com:443 -m -b 7 -c 5
+```
+
+When `-billing-day` is set:
+- The report contains one row per cycle (oldest → newest, with the in-progress
+  cycle last), matching the schema of the Teleport portal's Usage History page.
+- Each cycle has its own detailed per-user ZTA/IG breakdown underneath.
+- Anchor days that exceed a given month's length (e.g. 31 in February) are
+  clamped to the last day of that month.
+- All cycle math is in UTC. The script uses the audit log's `time` field to
+  bucket each event into a cycle.
+
+Without `-billing-day` (default), the script keeps its original rolling-window
+behavior driven by `daysBack` in the source.
+
+Caveat: events older than your cluster's audit log retention will not be
+returned, so older cycles may be silently empty. A warning is logged if the
+requested window exceeds ~90 days.
+
 ## Authentication
 
 The script automatically handles authentication based on your configuration:
@@ -250,12 +280,14 @@ version: v7
 ### Script arguments
 
 ```bash
-Usage: run.sh -p <teleport proxy address> [-i <identity file path>] [-m] [-t] [-v] [-x]
+Usage: run.sh -p <teleport proxy address> [-i <identity file path>] [-m] [-t] [-b <day>] [-c <n>] [-v] [-x]
 
   -p  Teleport proxy address (required). If no port is specified, :443 is assumed.
   -i  Optional identity file path.
   -m  Run MAU script (mau.go)
   -t  Run TPR script (tpr.go)
+  -b  Billing cycle anchor day (1-31). Aligns reports with Teleport billing cycles.
+  -c  Number of completed cycles to include (default 3, requires -b).
   -v  Output version and exit
   -x  Enable debugging information for 'go get'
 
@@ -263,4 +295,5 @@ Examples:
   run.sh -p example.teleport.sh -m
   run.sh -p example.teleport.sh:443 -i /path/to/identity -t
   run.sh -p example.teleport.sh -m -t
+  run.sh -p example.teleport.sh -m -b 7 -c 3
 ```

--- a/tools/teleport-api-scripts/TPR_README.md
+++ b/tools/teleport-api-scripts/TPR_README.md
@@ -60,6 +60,36 @@ dataRetentionDays = 90  // Keep 90 days of historical data instead of 30 (defaul
 eventBatchSize = 10000  // Increase batch size for better performance (default: 5000)
 ```
 
+## Billing Cycles
+
+Teleport bills against monthly cycles anchored to a customer-specific day, not
+the 1st of each month. To append a per-cycle history table to each report (so
+it lines up with the "Usage History" view in Teleport Cloud), pass
+`-billing-day` with your anchor day (1-31):
+
+```bash
+# Aligned to cycles starting on the 7th of each month (e.g. 7 May - 6 Jun)
+bash ./run.sh -p teleport.example.com:443 -t -b 7
+
+# Include 5 completed cycles in addition to the in-progress one (default: 3)
+bash ./run.sh -p teleport.example.com:443 -t -b 7 -c 5
+```
+
+When `-billing-day` is set, each report adds a `BILLING CYCLE HISTORY` section
+(or `cycle_history` array in JSON) with one row per cycle. Per-cycle resource
+counts are the **peak** (`MAX`) within the cycle window — each row in the
+SQLite history is a point-in-time snapshot, so the peak is the most defensible
+single number to compare against the portal's per-cycle figure. SPIFFE ID
+counts are summed across the cycle.
+
+Anchor days that exceed a given month's length (e.g. 31 in February) are
+clamped to the last day of that month. All cycle math is in UTC.
+
+Caveat: per-cycle history is bounded by what's in the SQLite database. If you
+request `-cycles N` spanning more than `dataRetentionDays` (default 30),
+older cycles will be empty until the tracker has been running long enough.
+Bump `dataRetentionDays` in the source to retain longer history.
+
 ## Authentication
 
 The script automatically handles authentication based on your configuration:
@@ -378,12 +408,14 @@ version: v7
 ### Script arguments
 
 ```bash
-Usage: run.sh -p <teleport proxy address> [-i <identity file path>] [-m] [-t] [-v] [-x]
+Usage: run.sh -p <teleport proxy address> [-i <identity file path>] [-m] [-t] [-b <day>] [-c <n>] [-v] [-x]
 
   -p  Teleport proxy address (required). If no port is specified, :443 is assumed.
   -i  Optional identity file path.
   -m  Run MAU script (mau.go)
   -t  Run TPR script (tpr.go)
+  -b  Billing cycle anchor day (1-31). Aligns reports with Teleport billing cycles.
+  -c  Number of completed cycles to include (default 3, requires -b).
   -v  Output version and exit
   -x  Enable debugging information for 'go get'
 
@@ -391,4 +423,5 @@ Examples:
   run.sh -p example.teleport.sh -m
   run.sh -p example.teleport.sh:443 -i /path/to/identity -t
   run.sh -p example.teleport.sh -m -t
+  run.sh -p example.teleport.sh -t -b 7 -c 3
 ```

--- a/tools/teleport-api-scripts/mau.go
+++ b/tools/teleport-api-scripts/mau.go
@@ -105,6 +105,224 @@ func sortedKeys[T any](m map[string]T) []string {
 	return keys
 }
 
+// cycleBounds is a half-open billing-cycle window [Start, End).
+type cycleBounds struct {
+	Start      time.Time
+	End        time.Time
+	Label      string
+	InProgress bool
+}
+
+// daysIn returns the number of days in the given year/month.
+func daysIn(year int, month time.Month) int {
+	return time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC).Day()
+}
+
+// cycleStart returns the anchor-day 00:00 UTC for year/month, clamped to the
+// last day of the month when anchor exceeds that month's length.
+func cycleStart(year int, month time.Month, anchor int) time.Time {
+	d := anchor
+	if last := daysIn(year, month); d > last {
+		d = last
+	}
+	return time.Date(year, month, d, 0, 0, 0, 0, time.UTC)
+}
+
+// cycleContaining returns the billing cycle whose half-open window contains t.
+func cycleContaining(t time.Time, anchor int) cycleBounds {
+	t = t.UTC()
+	start := cycleStart(t.Year(), t.Month(), anchor)
+	if t.Before(start) {
+		prevYear, prevMonth := t.Year(), t.Month()-1
+		if prevMonth < 1 {
+			prevYear--
+			prevMonth = 12
+		}
+		start = cycleStart(prevYear, prevMonth, anchor)
+	}
+	nextYear, nextMonth := start.Year(), start.Month()+1
+	if nextMonth > 12 {
+		nextYear++
+		nextMonth = 1
+	}
+	end := cycleStart(nextYear, nextMonth, anchor)
+	return cycleBounds{
+		Start: start,
+		End:   end,
+		Label: fmt.Sprintf("%s - %s",
+			start.Format("2 Jan 2006"),
+			end.Add(-24*time.Hour).Format("2 Jan 2006")),
+	}
+}
+
+// lastNCycles returns the cycle containing now plus n fully-completed preceding
+// cycles, oldest-first. The cycle containing now is marked InProgress.
+func lastNCycles(now time.Time, anchor, n int) []cycleBounds {
+	current := cycleContaining(now, anchor)
+	current.InProgress = true
+	out := []cycleBounds{current}
+	for i := 0; i < n; i++ {
+		// Pick any instant inside the previous cycle (one day before this start).
+		prev := out[len(out)-1].Start.Add(-24 * time.Hour)
+		out = append(out, cycleContaining(prev, anchor))
+	}
+	// Reverse to oldest-first.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// cycleAccum collects per-user activity for a single billing cycle (or, when
+// no -billing-day is set, the whole rolling window).
+type cycleAccum struct {
+	userResourceUsage map[string]*UserResourceUsage
+	userIGUsage       map[string]*UserIGUsage
+	userKind          map[string]UserKindLabel
+	totalLogins       int
+}
+
+func newCycleAccum() *cycleAccum {
+	return &cycleAccum{
+		userResourceUsage: make(map[string]*UserResourceUsage),
+		userIGUsage:       make(map[string]*UserIGUsage),
+		userKind:          make(map[string]UserKindLabel),
+	}
+}
+
+// ingest applies one decoded audit event to this accumulator.
+func (a *cycleAccum) ingest(raw map[string]interface{}) {
+	user, ok := raw["user"].(string)
+	if !ok || user == "" {
+		return
+	}
+	kind := classifyUserKind(raw)
+	if existing, ok := a.userKind[user]; !ok {
+		a.userKind[user] = kind
+	} else if existing != UserKindBot && kind == UserKindBot {
+		a.userKind[user] = UserKindBot
+	}
+	eventType, ok := raw["event"].(string)
+	if !ok {
+		return
+	}
+	switch eventType {
+	case "user.login":
+		if a.userResourceUsage[user] == nil {
+			a.userResourceUsage[user] = &UserResourceUsage{}
+		}
+		if raw["success"] == true {
+			a.userResourceUsage[user].LoginCount++
+			a.totalLogins++
+		}
+	case "session.start":
+		if a.userResourceUsage[user] == nil {
+			a.userResourceUsage[user] = &UserResourceUsage{}
+		}
+		if kubeCluster, exists := raw["kubernetes_cluster"]; exists && kubeCluster != nil {
+			a.userResourceUsage[user].Kubernetes++
+		} else {
+			a.userResourceUsage[user].SSH++
+		}
+	case "db.session.start":
+		if a.userResourceUsage[user] == nil {
+			a.userResourceUsage[user] = &UserResourceUsage{}
+		}
+		a.userResourceUsage[user].Database++
+	case "app.session.start":
+		if a.userResourceUsage[user] == nil {
+			a.userResourceUsage[user] = &UserResourceUsage{}
+		}
+		a.userResourceUsage[user].Application++
+	case "windows.desktop.session.start":
+		if a.userResourceUsage[user] == nil {
+			a.userResourceUsage[user] = &UserResourceUsage{}
+		}
+		a.userResourceUsage[user].Desktop++
+	case "kube.request":
+		if a.userResourceUsage[user] == nil {
+			a.userResourceUsage[user] = &UserResourceUsage{}
+		}
+		a.userResourceUsage[user].Kubernetes++
+	case "access_request.create":
+		if a.userIGUsage[user] == nil {
+			a.userIGUsage[user] = &UserIGUsage{}
+		}
+		a.userIGUsage[user].AccessRequestsCreated++
+	case "access_request.review":
+		if a.userIGUsage[user] == nil {
+			a.userIGUsage[user] = &UserIGUsage{}
+		}
+		a.userIGUsage[user].AccessRequestsReviewed++
+	case "access_list.member.create", "access_list.member.update":
+		if a.userIGUsage[user] == nil {
+			a.userIGUsage[user] = &UserIGUsage{}
+		}
+		a.userIGUsage[user].AccessListsMemberships++
+	case "access_list.review":
+		if a.userIGUsage[user] == nil {
+			a.userIGUsage[user] = &UserIGUsage{}
+		}
+		a.userIGUsage[user].AccessListsReviewed++
+	case "saml.idp.auth":
+		if a.userIGUsage[user] == nil {
+			a.userIGUsage[user] = &UserIGUsage{}
+		}
+		a.userIGUsage[user].SAMLIDPSessions++
+	}
+}
+
+// cycleSummary holds the filtered + counted view of one accumulator.
+type cycleSummary struct {
+	ztaMAUAll     map[string]*UserResourceUsage
+	igMAUAll      map[string]*UserIGUsage
+	ztaHumanCount int
+	igHumanCount  int
+	mwiBotCount   int
+}
+
+func (a *cycleAccum) summarize() cycleSummary {
+	ztaMAUAll := make(map[string]*UserResourceUsage)
+	for user, usage := range a.userResourceUsage {
+		if usage.SSH > 0 || usage.Kubernetes > 0 || usage.Database > 0 ||
+			usage.Application > 0 || usage.Desktop > 0 {
+			ztaMAUAll[user] = usage
+		}
+	}
+	igMAUAll := make(map[string]*UserIGUsage)
+	for user, usage := range a.userIGUsage {
+		if usage.AccessRequestsCreated > 0 || usage.AccessRequestsReviewed > 0 ||
+			usage.AccessListsMemberships > 0 || usage.AccessListsReviewed > 0 ||
+			usage.SAMLIDPSessions > 0 {
+			igMAUAll[user] = usage
+		}
+	}
+	ztaHumanCount := 0
+	igHumanCount := 0
+	botSet := make(map[string]struct{})
+	for user := range ztaMAUAll {
+		if a.userKind[user] == UserKindBot {
+			botSet[user] = struct{}{}
+		} else {
+			ztaHumanCount++
+		}
+	}
+	for user := range igMAUAll {
+		if a.userKind[user] == UserKindBot {
+			botSet[user] = struct{}{}
+		} else {
+			igHumanCount++
+		}
+	}
+	return cycleSummary{
+		ztaMAUAll:     ztaMAUAll,
+		igMAUAll:      igMAUAll,
+		ztaHumanCount: ztaHumanCount,
+		igHumanCount:  igHumanCount,
+		mwiBotCount:   len(botSet),
+	}
+}
+
 func main() {
 	// Command-line flags
 	proxyFlag := flag.String(
@@ -123,6 +341,18 @@ func main() {
 		"format",
 		"text",
 		"Output file type - text or json",
+	)
+
+	billingDayFlag := flag.Int(
+		"billing-day",
+		0,
+		"Billing cycle anchor day (1-31). When set, the report is aligned to Teleport billing cycles instead of a rolling daysBack window.",
+	)
+
+	cyclesFlag := flag.Int(
+		"cycles",
+		3,
+		"Number of completed cycles to include alongside the in-progress cycle (only used with -billing-day).",
 	)
 
 	flag.Parse()
@@ -145,6 +375,16 @@ func main() {
 		if _, err := os.Stat(identityFilePath); err != nil {
 			log.Fatalf("identity file not accessible: %v", err)
 		}
+	}
+
+	billingDay := *billingDayFlag
+	if billingDay < 0 || billingDay > 31 {
+		log.Fatalf("invalid -billing-day %d (expected 1-31, or 0 to disable)", billingDay)
+	}
+	billingDayAnchor = billingDay
+	cyclesCount := *cyclesFlag
+	if cyclesCount < 0 {
+		log.Fatalf("invalid -cycles %d (must be >= 0)", cyclesCount)
 	}
 
 	ctx := context.Background()
@@ -170,17 +410,34 @@ func main() {
 	}
 	defer clt.Close()
 
-	// Define the time range based on configuration
-	fromUTC := time.Now().AddDate(0, 0, -daysBack)
-	toUTC := time.Now()
+	// Define the time range and per-cycle accumulators.
+	var (
+		fromUTC, toUTC time.Time
+		cycles         []cycleBounds
+		accums         []*cycleAccum
+		single         *cycleAccum
+	)
+	if billingDay > 0 {
+		now := time.Now().UTC()
+		cycles = lastNCycles(now, billingDay, cyclesCount)
+		accums = make([]*cycleAccum, len(cycles))
+		for i := range accums {
+			accums[i] = newCycleAccum()
+		}
+		fromUTC = cycles[0].Start
+		toUTC = now
+		log.Printf("[INFO] Billing-cycle mode: anchor=%d, %d cycle(s) from %s to %s",
+			billingDay, len(cycles), fromUTC.Format("2006-01-02"), toUTC.Format("2006-01-02"))
+		if now.Sub(fromUTC) > 90*24*time.Hour {
+			log.Printf("[WARN] Requested window spans %.0f days; older cycles may be empty due to audit log retention.",
+				now.Sub(fromUTC).Hours()/24)
+		}
+	} else {
+		fromUTC = time.Now().AddDate(0, 0, -daysBack)
+		toUTC = time.Now()
+		single = newCycleAccum()
+	}
 
-	userResourceUsage := make(map[string]*UserResourceUsage)
-	userIGUsage := make(map[string]*UserIGUsage)
-
-	// Track per-user kind (Human/Bot) based on events
-	userKind := make(map[string]UserKindLabel)
-
-	totalLogins := 0
 	nextKey := ""
 
 	// Event types to track for both ZTA MAU and IG MAU
@@ -233,97 +490,21 @@ func main() {
 				continue
 			}
 
-			user, ok := raw["user"].(string)
-			if !ok || user == "" {
-				continue
-			}
-
-			// Track kind (prefer Bot if we ever see Bot for that username)
-			kind := classifyUserKind(raw)
-			if existing, ok := userKind[user]; !ok {
-				userKind[user] = kind
-			} else if existing != UserKindBot && kind == UserKindBot {
-				userKind[user] = UserKindBot
-			}
-
-			eventType, ok := raw["event"].(string)
-			if !ok {
-				continue
-			}
-
-			// Process ZTA MAU events (resource access)
-			switch eventType {
-			case "user.login":
-				if userResourceUsage[user] == nil {
-					userResourceUsage[user] = &UserResourceUsage{}
+			if billingDay > 0 {
+				et := event.GetTime().UTC()
+				idx := -1
+				for i, c := range cycles {
+					if !et.Before(c.Start) && et.Before(c.End) {
+						idx = i
+						break
+					}
 				}
-				if raw["success"] == true {
-					userResourceUsage[user].LoginCount++
-					totalLogins++
+				if idx < 0 {
+					continue
 				}
-			case "session.start":
-				if userResourceUsage[user] == nil {
-					userResourceUsage[user] = &UserResourceUsage{}
-				}
-				// Check if this is a kubernetes session by looking for kubernetes_cluster field
-				if kubeCluster, exists := raw["kubernetes_cluster"]; exists && kubeCluster != nil {
-					userResourceUsage[user].Kubernetes++
-				} else {
-					userResourceUsage[user].SSH++
-				}
-			case "db.session.start":
-				if userResourceUsage[user] == nil {
-					userResourceUsage[user] = &UserResourceUsage{}
-				}
-				userResourceUsage[user].Database++
-			case "app.session.start":
-				if userResourceUsage[user] == nil {
-					userResourceUsage[user] = &UserResourceUsage{}
-				}
-				userResourceUsage[user].Application++
-			case "windows.desktop.session.start":
-				if userResourceUsage[user] == nil {
-					userResourceUsage[user] = &UserResourceUsage{}
-				}
-				userResourceUsage[user].Desktop++
-			case "kube.request":
-				if userResourceUsage[user] == nil {
-					userResourceUsage[user] = &UserResourceUsage{}
-				}
-				userResourceUsage[user].Kubernetes++
-			}
-
-			// Process IG MAU events (identity governance)
-			switch eventType {
-			case "access_request.create":
-				if userIGUsage[user] == nil {
-					userIGUsage[user] = &UserIGUsage{}
-				}
-				userIGUsage[user].AccessRequestsCreated++
-			case "access_request.review":
-				// For reviews, the reviewer is in the "user" field
-				if userIGUsage[user] == nil {
-					userIGUsage[user] = &UserIGUsage{}
-				}
-				userIGUsage[user].AccessRequestsReviewed++
-			case "access_list.member.create", "access_list.member.update":
-				// Track when users get roles assigned through access list membership
-				if userIGUsage[user] == nil {
-					userIGUsage[user] = &UserIGUsage{}
-				}
-				userIGUsage[user].AccessListsMemberships++
-			case "access_list.review":
-				// Track when users review access lists
-				if userIGUsage[user] == nil {
-					userIGUsage[user] = &UserIGUsage{}
-				}
-				userIGUsage[user].AccessListsReviewed++
-			case "saml.idp.auth":
-				// Track SAML IdP sessions
-				if userIGUsage[user] == nil {
-					userIGUsage[user] = &UserIGUsage{}
-				}
-				userIGUsage[user].SAMLIDPSessions++
+				accums[idx].ingest(raw)
+			} else {
+				single.ingest(raw)
 			}
 		}
 
@@ -334,50 +515,16 @@ func main() {
 		nextKey = newNextKey
 	}
 
-	// Filter ZTA MAU users who have actually used resources (not just logged in)
-	ztaMAUAll := make(map[string]*UserResourceUsage)
-	for user, usage := range userResourceUsage {
-		if usage.SSH > 0 || usage.Kubernetes > 0 || usage.Database > 0 || usage.Application > 0 || usage.Desktop > 0 {
-			ztaMAUAll[user] = usage
+	if billingDay > 0 {
+		summaries := make([]cycleSummary, len(cycles))
+		for i, a := range accums {
+			summaries[i] = a.summarize()
 		}
+		writePerCycleReport(cycles, accums, summaries)
+	} else {
+		s := single.summarize()
+		writeUserReport(s.ztaMAUAll, s.igMAUAll, single.userKind, single.totalLogins, s.ztaHumanCount, s.igHumanCount, s.mwiBotCount)
 	}
-
-	// Filter IG MAU users who have used identity governance features
-	igMAUAll := make(map[string]*UserIGUsage)
-	for user, usage := range userIGUsage {
-		if usage.AccessRequestsCreated > 0 || usage.AccessRequestsReviewed > 0 ||
-			usage.AccessListsMemberships > 0 || usage.AccessListsReviewed > 0 ||
-			usage.SAMLIDPSessions > 0 {
-			igMAUAll[user] = usage
-		}
-	}
-
-	// Compute totals:
-	// - ZTA MAU (humans only)
-	// - IG MAU (humans only)
-	// - MWI (bots only) = unique bot users across either ZTA/IG activity
-	ztaHumanCount := 0
-	igHumanCount := 0
-	botSet := make(map[string]struct{})
-
-	for user := range ztaMAUAll {
-		if userKind[user] == UserKindBot {
-			botSet[user] = struct{}{}
-		} else {
-			ztaHumanCount++
-		}
-	}
-	for user := range igMAUAll {
-		if userKind[user] == UserKindBot {
-			botSet[user] = struct{}{}
-		} else {
-			igHumanCount++
-		}
-	}
-	mwiBotCount := len(botSet)
-
-	// Write report to file based on selected format
-	writeUserReport(ztaMAUAll, igMAUAll, userKind, totalLogins, ztaHumanCount, igHumanCount, mwiBotCount)
 }
 
 // Writes the user activity report to a file in either JSON or text format
@@ -443,73 +590,7 @@ func writeUserReport(
 		output += fmt.Sprintf("Total Successful Logins: %d\n", totalLogins)
 		output += "=================================================\n\n"
 
-		// ZTA MAU Report Section (includes both humans & bots)
-		if len(ztaMAU) > 0 {
-			output += "ZERO TRUST ACCESS (ZTA MAU) - Resource Usage\n"
-			output += "-------------------------------------------------\n"
-
-			// Calculate max username length for ZTA MAU
-			maxUserLen := 4
-			for user := range ztaMAU {
-				if len(user) > maxUserLen {
-					maxUserLen = len(user)
-				}
-			}
-
-			userColWidth := maxUserLen + 2
-			kindColWidth := 6 // Needs to fit "Human" or "Bot"
-
-			output += fmt.Sprintf("%-*s  %-*s  %-8s  %-8s  %-8s  %-8s  %-8s  %-8s\n",
-				userColWidth, "User",
-				kindColWidth, "Kind",
-				"Logins", "SSH", "Kube", "DB", "App", "Desktop")
-
-			separatorLen := userColWidth + 2 + kindColWidth + 2 + 8*6 + 2*6
-			output += fmt.Sprintf("%s\n", strings.Repeat("-", separatorLen))
-
-			for _, user := range sortedKeys(ztaMAU) {
-				usage := ztaMAU[user]
-				kind := userKind[user]
-				if kind == "" {
-					kind = UserKindHuman
-				}
-
-				output += fmt.Sprintf("%-*s  %-*s  %-8d  %-8d  %-8d  %-8d  %-8d  %-8d\n",
-					userColWidth, user,
-					kindColWidth, kind,
-					usage.LoginCount, usage.SSH, usage.Kubernetes,
-					usage.Database, usage.Application, usage.Desktop)
-			}
-			output += "\n"
-		}
-
-		// IG MAU Report Section
-		if len(igMAU) > 0 {
-			output += "IDENTITY GOVERNANCE (IG MAU) - Feature Usage\n"
-			output += "-------------------------------------------------\n"
-
-			// Calculate max username length for IG MAU
-			maxUserLen := 4
-			for user := range igMAU {
-				if len(user) > maxUserLen {
-					maxUserLen = len(user)
-				}
-			}
-
-			userColWidth := maxUserLen + 2
-			output += fmt.Sprintf("%-*s  %-12s  %-12s  %-12s  %-12s  %-12s\n",
-				userColWidth, "User", "Req Created", "Req Reviewed", "List Member", "List Review", "SAML IdP")
-
-			separatorLen := userColWidth + 2 + 12*5 + 2*5
-			output += fmt.Sprintf("%s\n", strings.Repeat("-", separatorLen))
-
-			for _, user := range sortedKeys(igMAU) {
-				usage := igMAU[user]
-				output += fmt.Sprintf("%-*s  %-12d  %-12d  %-12d  %-12d  %-12d\n",
-					userColWidth, user, usage.AccessRequestsCreated, usage.AccessRequestsReviewed,
-					usage.AccessListsMemberships, usage.AccessListsReviewed, usage.SAMLIDPSessions)
-			}
-		}
+		output += formatUserTables(ztaMAU, igMAU, userKind)
 
 		_, err = file.WriteString(output)
 		if err != nil {
@@ -519,3 +600,187 @@ func writeUserReport(
 		log.Printf("[INFO] Text report successfully written to %s at %s", outputFilenameText, timestamp)
 	}
 }
+
+// formatUserTables renders the ZTA and IG per-user tables for a single cycle.
+func formatUserTables(
+	ztaMAU map[string]*UserResourceUsage,
+	igMAU map[string]*UserIGUsage,
+	userKind map[string]UserKindLabel,
+) string {
+	var output string
+
+	if len(ztaMAU) > 0 {
+		output += "ZERO TRUST ACCESS (ZTA MAU) - Resource Usage\n"
+		output += "-------------------------------------------------\n"
+
+		maxUserLen := 4
+		for user := range ztaMAU {
+			if len(user) > maxUserLen {
+				maxUserLen = len(user)
+			}
+		}
+
+		userColWidth := maxUserLen + 2
+		kindColWidth := 6
+
+		output += fmt.Sprintf("%-*s  %-*s  %-8s  %-8s  %-8s  %-8s  %-8s  %-8s\n",
+			userColWidth, "User",
+			kindColWidth, "Kind",
+			"Logins", "SSH", "Kube", "DB", "App", "Desktop")
+
+		separatorLen := userColWidth + 2 + kindColWidth + 2 + 8*6 + 2*6
+		output += fmt.Sprintf("%s\n", strings.Repeat("-", separatorLen))
+
+		for _, user := range sortedKeys(ztaMAU) {
+			usage := ztaMAU[user]
+			kind := userKind[user]
+			if kind == "" {
+				kind = UserKindHuman
+			}
+
+			output += fmt.Sprintf("%-*s  %-*s  %-8d  %-8d  %-8d  %-8d  %-8d  %-8d\n",
+				userColWidth, user,
+				kindColWidth, kind,
+				usage.LoginCount, usage.SSH, usage.Kubernetes,
+				usage.Database, usage.Application, usage.Desktop)
+		}
+		output += "\n"
+	}
+
+	if len(igMAU) > 0 {
+		output += "IDENTITY GOVERNANCE (IG MAU) - Feature Usage\n"
+		output += "-------------------------------------------------\n"
+
+		maxUserLen := 4
+		for user := range igMAU {
+			if len(user) > maxUserLen {
+				maxUserLen = len(user)
+			}
+		}
+
+		userColWidth := maxUserLen + 2
+		output += fmt.Sprintf("%-*s  %-12s  %-12s  %-12s  %-12s  %-12s\n",
+			userColWidth, "User", "Req Created", "Req Reviewed", "List Member", "List Review", "SAML IdP")
+
+		separatorLen := userColWidth + 2 + 12*5 + 2*5
+		output += fmt.Sprintf("%s\n", strings.Repeat("-", separatorLen))
+
+		for _, user := range sortedKeys(igMAU) {
+			usage := igMAU[user]
+			output += fmt.Sprintf("%-*s  %-12d  %-12d  %-12d  %-12d  %-12d\n",
+				userColWidth, user, usage.AccessRequestsCreated, usage.AccessRequestsReviewed,
+				usage.AccessListsMemberships, usage.AccessListsReviewed, usage.SAMLIDPSessions)
+		}
+	}
+
+	return output
+}
+
+// cycleLabel returns the human-readable cycle label, suffixed when in progress.
+func cycleLabel(c cycleBounds) string {
+	if c.InProgress {
+		return c.Label + " (in progress)"
+	}
+	return c.Label
+}
+
+// writePerCycleReport emits a billing-cycle-aligned report (text or JSON).
+func writePerCycleReport(cycles []cycleBounds, accums []*cycleAccum, summaries []cycleSummary) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+
+	if reportFormat == "json" {
+		cycleData := make([]map[string]interface{}, len(cycles))
+		for i, c := range cycles {
+			s := summaries[i]
+			cycleData[i] = map[string]interface{}{
+				"label":                   c.Label,
+				"start":                   c.Start.Format(time.RFC3339),
+				"end":                     c.End.Format(time.RFC3339),
+				"in_progress":             c.InProgress,
+				"total_ztamau_users":      s.ztaHumanCount,
+				"total_igmau_users":       s.igHumanCount,
+				"total_mwi_bots":          s.mwiBotCount,
+				"total_successful_logins": accums[i].totalLogins,
+				"user_kind":               accums[i].userKind,
+				"zta_resource_usage_all":  s.ztaMAUAll,
+				"ig_feature_usage_all":    s.igMAUAll,
+			}
+		}
+
+		reportData := map[string]interface{}{
+			"teleport_proxy_url": teleportProxyURL,
+			"timestamp":          timestamp,
+			"billing_anchor_day": billingDayAnchor,
+			"cycles":             cycleData,
+		}
+
+		jsonData, err := json.MarshalIndent(reportData, "", "  ")
+		if err != nil {
+			log.Fatalf("Failed to generate JSON report: %v", err)
+		}
+
+		jsonFile, err := os.OpenFile(outputFilenameJson, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			log.Fatalf("Failed to open JSON report file: %v", err)
+		}
+		defer jsonFile.Close()
+
+		if _, err := jsonFile.Write(jsonData); err != nil {
+			log.Fatalf("Failed to write JSON report: %v", err)
+		}
+		log.Printf("[INFO] JSON report successfully written to %s at %s", outputFilenameJson, timestamp)
+		return
+	}
+
+	// Text output
+	file, err := os.OpenFile(outputFilenameText, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.Fatalf("Failed to open report file: %v", err)
+	}
+	defer file.Close()
+
+	output := fmt.Sprintf("\n[%s] Teleport Active Users Report (billing cycles)\n", timestamp)
+	output += fmt.Sprintf("Teleport Proxy URL: %s\n", teleportProxyURL)
+	output += fmt.Sprintf("Billing anchor day: %d\n", billingDayAnchor)
+	output += "=================================================\n"
+
+	// Per-cycle summary table.
+	labelWidth := len("Cycle")
+	for _, c := range cycles {
+		if l := len(cycleLabel(c)); l > labelWidth {
+			labelWidth = l
+		}
+	}
+	labelWidth += 2
+	output += fmt.Sprintf("%-*s  %-8s  %-8s  %-6s  %-8s\n",
+		labelWidth, "Cycle", "ZTA MAU", "IG MAU", "MWI", "Logins")
+	output += strings.Repeat("-", labelWidth+2+8+2+8+2+6+2+8) + "\n"
+	for i, c := range cycles {
+		s := summaries[i]
+		output += fmt.Sprintf("%-*s  %-8d  %-8d  %-6d  %-8d\n",
+			labelWidth, cycleLabel(c),
+			s.ztaHumanCount, s.igHumanCount, s.mwiBotCount, accums[i].totalLogins)
+	}
+	output += "=================================================\n\n"
+
+	// Per-cycle detail tables.
+	for i, c := range cycles {
+		s := summaries[i]
+		output += fmt.Sprintf("--- %s ---\n", cycleLabel(c))
+		tables := formatUserTables(s.ztaMAUAll, s.igMAUAll, accums[i].userKind)
+		if tables == "" {
+			output += "(no activity in this cycle)\n\n"
+		} else {
+			output += tables + "\n"
+		}
+	}
+
+	if _, err = file.WriteString(output); err != nil {
+		log.Fatalf("Failed to write to report file: %v", err)
+	}
+	log.Printf("[INFO] Text report successfully written to %s at %s", outputFilenameText, timestamp)
+}
+
+// billingDayAnchor mirrors the -billing-day flag so report writers can include
+// it without threading an extra argument through.
+var billingDayAnchor int

--- a/tools/teleport-api-scripts/run.sh
+++ b/tools/teleport-api-scripts/run.sh
@@ -22,12 +22,14 @@ to_epoch() {
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") -p <teleport proxy address> [-i <identity file path>] [-m] [-t] [-v] [-x]
+Usage: $(basename "$0") -p <teleport proxy address> [-i <identity file path>] [-m] [-t] [-b <day>] [-c <n>] [-v] [-x]
 
   -p  Teleport proxy address (required). If no port is specified, :443 is assumed.
   -i  Optional identity file path.
   -m  Run MAU script (mau.go)
   -t  Run TPR script (tpr.go)
+  -b  Billing cycle anchor day (1-31). Aligns reports with Teleport billing cycles.
+  -c  Number of completed cycles to include (default 3, requires -b).
   -v  Output version and exit
   -x  Enable debugging information for 'go get'
 
@@ -35,6 +37,7 @@ Examples:
   $(basename "$0") -p example.teleport.sh -m
   $(basename "$0") -p example.teleport.sh:443 -i /path/to/identity -t
   $(basename "$0") -p example.teleport.sh -m -t
+  $(basename "$0") -p example.teleport.sh -m -b 7 -c 3
 EOF
 }
 
@@ -43,13 +46,17 @@ PROXY=""
 IDENTITY_FILE=""
 RUN_MAU=0
 RUN_TPR=0
+BILLING_DAY=""
+CYCLES=""
 SHOW_VERSION=0
 GO_GET_DEBUG=0
 
-while getopts ":p:i:mtvx" opt; do
+while getopts ":p:i:b:c:mtvx" opt; do
   case "$opt" in
     p) PROXY="$OPTARG" ;;
     i) IDENTITY_FILE="$OPTARG" ;;
+    b) BILLING_DAY="$OPTARG" ;;
+    c) CYCLES="$OPTARG" ;;
     m) RUN_MAU=1 ;;
     t) RUN_TPR=1 ;;
     v) SHOW_VERSION=1 ;;
@@ -100,6 +107,15 @@ if [[ "${STATUS}" != "200" ]]; then
   exit 2
 fi
 
+# build extra args from billing-cycle flags
+EXTRA_ARGS=""
+if [[ -n "${BILLING_DAY}" ]]; then
+  EXTRA_ARGS+=" -billing-day ${BILLING_DAY}"
+fi
+if [[ -n "${CYCLES}" ]]; then
+  EXTRA_ARGS+=" -cycles ${CYCLES}"
+fi
+
 # handle identity file
 IDENTITY_FILE_STANZA=""
 if [[ -n "${IDENTITY_FILE}" ]]; then
@@ -143,11 +159,11 @@ go mod tidy
 if [[ "${RUN_MAU}" -eq 1 ]]; then
   echo "Running MAU script"
   #shellcheck disable=SC2086
-  go run mau.go -proxy ${PROXY}${IDENTITY_FILE_STANZA}
+  go run mau.go -proxy ${PROXY}${IDENTITY_FILE_STANZA}${EXTRA_ARGS}
 fi
 
 if [[ "${RUN_TPR}" -eq 1 ]]; then
   echo "Running TPR script"
   #shellcheck disable=SC2086
-  go run tpr.go -proxy ${PROXY}${IDENTITY_FILE_STANZA}
+  go run tpr.go -proxy ${PROXY}${IDENTITY_FILE_STANZA}${EXTRA_ARGS}
 fi

--- a/tools/teleport-api-scripts/tpr.go
+++ b/tools/teleport-api-scripts/tpr.go
@@ -61,7 +61,70 @@ var (
 	resourcesMutex sync.Mutex                  // Mutex to ensure safe concurrent access
 	logFile        *os.File                    // File handle for logging & report outputs
 	db             *sql.DB                     // SQLite database connection
+
+	billingDayAnchor int // -billing-day value (0 = disabled)
+	cyclesCount      int // -cycles value
 )
+
+// cycleBounds is a half-open billing-cycle window [Start, End).
+type cycleBounds struct {
+	Start      time.Time
+	End        time.Time
+	Label      string
+	InProgress bool
+}
+
+func daysIn(year int, month time.Month) int {
+	return time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC).Day()
+}
+
+func cycleStart(year int, month time.Month, anchor int) time.Time {
+	d := anchor
+	if last := daysIn(year, month); d > last {
+		d = last
+	}
+	return time.Date(year, month, d, 0, 0, 0, 0, time.UTC)
+}
+
+func cycleContaining(t time.Time, anchor int) cycleBounds {
+	t = t.UTC()
+	start := cycleStart(t.Year(), t.Month(), anchor)
+	if t.Before(start) {
+		prevYear, prevMonth := t.Year(), t.Month()-1
+		if prevMonth < 1 {
+			prevYear--
+			prevMonth = 12
+		}
+		start = cycleStart(prevYear, prevMonth, anchor)
+	}
+	nextYear, nextMonth := start.Year(), start.Month()+1
+	if nextMonth > 12 {
+		nextYear++
+		nextMonth = 1
+	}
+	end := cycleStart(nextYear, nextMonth, anchor)
+	return cycleBounds{
+		Start: start,
+		End:   end,
+		Label: fmt.Sprintf("%s - %s",
+			start.Format("2 Jan 2006"),
+			end.Add(-24*time.Hour).Format("2 Jan 2006")),
+	}
+}
+
+func lastNCycles(now time.Time, anchor, n int) []cycleBounds {
+	current := cycleContaining(now, anchor)
+	current.InProgress = true
+	out := []cycleBounds{current}
+	for i := 0; i < n; i++ {
+		prev := out[len(out)-1].Start.Add(-24 * time.Hour)
+		out = append(out, cycleContaining(prev, anchor))
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
 
 // Initializes logging, connects to a Teleport cluster, and continuously tracks protected resources (TPRs) and MWI.
 // 1. Initializes Logging & Database: Sets up structured logging and a SQLite database for TPR/MWI storage.
@@ -89,6 +152,18 @@ func main() {
 		"Path to Teleport identity file (optional - enables use of an identity file instead of ambient tsh credentials)",
 	)
 
+	billingDayFlag := flag.Int(
+		"billing-day",
+		0,
+		"Billing cycle anchor day (1-31). When set, an additional per-cycle history section is included in each report.",
+	)
+
+	cyclesFlag := flag.Int(
+		"cycles",
+		3,
+		"Number of completed cycles to include alongside the in-progress cycle (only used with -billing-day).",
+	)
+
 	flag.Parse()
 
 	teleportProxyURL = *proxyFlag
@@ -108,6 +183,23 @@ func main() {
 		// Validation
 		if _, err := os.Stat(identityFilePath); err != nil {
 			log.Fatalf("identity file not accessible: %v", err)
+		}
+	}
+
+	billingDayAnchor = *billingDayFlag
+	if billingDayAnchor < 0 || billingDayAnchor > 31 {
+		log.Fatalf("invalid -billing-day %d (expected 1-31, or 0 to disable)", billingDayAnchor)
+	}
+	cyclesCount = *cyclesFlag
+	if cyclesCount < 0 {
+		log.Fatalf("invalid -cycles %d (must be >= 0)", cyclesCount)
+	}
+	if billingDayAnchor > 0 {
+		oldest := lastNCycles(time.Now().UTC(), billingDayAnchor, cyclesCount)[0].Start
+		spanDays := int(time.Since(oldest).Hours() / 24)
+		if spanDays > dataRetentionDays {
+			log.Printf("[WARN] Requested -cycles=%d spans ~%d days but dataRetentionDays=%d; older cycles will be empty until SQLite history catches up.",
+				cyclesCount, spanDays, dataRetentionDays)
 		}
 	}
 
@@ -469,6 +561,16 @@ func writeReportsToFile() {
 		bots, botInstances, spiffeIDs = 0, 0, 0
 	}
 
+	// Per-cycle history (only populated when -billing-day is set).
+	var cycleHistory []map[string]interface{}
+	if billingDayAnchor > 0 {
+		cycles := lastNCycles(time.Now().UTC(), billingDayAnchor, cyclesCount)
+		cycleHistory = make([]map[string]interface{}, len(cycles))
+		for i, c := range cycles {
+			cycleHistory[i] = aggregateCycle(c)
+		}
+	}
+
 	if reportFormat == "json" {
 		// JSON output format
 		reportData := map[string]interface{}{
@@ -487,6 +589,10 @@ func writeReportsToFile() {
 				"bot_instances":     botInstances,
 				"spiffe_ids_issued": spiffeIDs,
 			},
+		}
+		if cycleHistory != nil {
+			reportData["billing_anchor_day"] = billingDayAnchor
+			reportData["cycle_history"] = cycleHistory
 		}
 
 		jsonData, err := json.MarshalIndent(reportData, "", "  ")
@@ -539,12 +645,130 @@ func writeReportsToFile() {
 		output += fmt.Sprintf("SPIFFE IDs Issued (this period): %d\n", spiffeIDs)
 		output += "=================================================\n"
 
+		if cycleHistory != nil {
+			output += "\nBILLING CYCLE HISTORY (peak within cycle for TPR/MWI, sum for SPIFFE)\n"
+			output += fmt.Sprintf("Anchor day: %d\n", billingDayAnchor)
+			output += "-------------------------------------------------\n"
+
+			labelWidth := len("Cycle")
+			for _, row := range cycleHistory {
+				if l := len(row["label_display"].(string)); l > labelWidth {
+					labelWidth = l
+				}
+			}
+			labelWidth += 2
+
+			output += fmt.Sprintf("%-*s  %-8s  %-8s  %-8s  %-8s  %-8s  %-8s  %-6s  %-8s\n",
+				labelWidth, "Cycle", "Total", "Apps", "Kube", "DBs", "WinDesk", "Nodes", "Bots", "SPIFFE")
+			output += strings.Repeat("-", labelWidth+2+8*8+2*7+6) + "\n"
+
+			cell := func(width int, v interface{}) string {
+				if v == nil {
+					return fmt.Sprintf("%-*s", width, "n/a")
+				}
+				return fmt.Sprintf("%-*d", width, v.(int))
+			}
+
+			anyMissing := false
+			for _, row := range cycleHistory {
+				if !row["tpr_available"].(bool) || !row["mwi_available"].(bool) {
+					anyMissing = true
+				}
+				output += fmt.Sprintf("%-*s  %s  %s  %s  %s  %s  %s  %s  %s\n",
+					labelWidth, row["label_display"].(string),
+					cell(8, row["total_tpr"]),
+					cell(8, row["applications"]),
+					cell(8, row["kubernetes"]),
+					cell(8, row["databases"]),
+					cell(8, row["windows_desktops"]),
+					cell(8, row["nodes"]),
+					cell(6, row["bots"]),
+					cell(8, row["spiffe_ids_issued"]))
+			}
+			if anyMissing {
+				output += "(n/a = no snapshot recorded in this cycle; the tracker must be running to collect data)\n"
+			}
+			output += "=================================================\n"
+		}
+
 		_, err = file.WriteString(output)
 		if err != nil {
 			log.Printf("[ERROR] Failed to write to report file: %v", err)
 		}
 
 		log.Printf("[INFO] Usage report updated successfully at %s", timestamp)
+	}
+}
+
+// aggregateCycle queries SQLite for TPR/MWI activity within one billing cycle.
+// Resource counts use the peak (MAX) within the window — each row is a snapshot,
+// so the peak is the most defensible single number to compare against the
+// portal's per-cycle figure. SPIFFE issuance uses SUM because each row records
+// the count for that interval (the in-memory counter resets after each insert,
+// see updateMetrics).
+func aggregateCycle(c cycleBounds) map[string]interface{} {
+	startStr := c.Start.Format("2006-01-02 15:04:05")
+	endStr := c.End.Format("2006-01-02 15:04:05")
+
+	var totalTPR, appTPR, kubeTPR, dbTPR, windowsTPR, nodeTPR sql.NullInt64
+	err := db.QueryRow(`
+		SELECT MAX(total_tpr), MAX(app_tpr), MAX(kube_tpr), MAX(db_tpr),
+		       MAX(windows_tpr), MAX(node_tpr)
+		  FROM tpr_data
+		 WHERE timestamp >= ? AND timestamp < ?`,
+		startStr, endStr,
+	).Scan(&totalTPR, &appTPR, &kubeTPR, &dbTPR, &windowsTPR, &nodeTPR)
+	if err != nil {
+		log.Printf("[ERROR] aggregateCycle TPR query failed for %s: %v", c.Label, err)
+	}
+
+	var botsMax, instMax, spiffeSum sql.NullInt64
+	err = db.QueryRow(`
+		SELECT MAX(bots), MAX(bot_instances), COALESCE(SUM(spiffe_ids_issued), 0)
+		  FROM mwi_data
+		 WHERE timestamp >= ? AND timestamp < ?`,
+		startStr, endStr,
+	).Scan(&botsMax, &instMax, &spiffeSum)
+	if err != nil {
+		log.Printf("[ERROR] aggregateCycle MWI query failed for %s: %v", c.Label, err)
+	}
+
+	display := c.Label
+	if c.InProgress {
+		display += " (in progress)"
+	}
+
+	// MAX(...) returns NULL when no rows match — that's our signal for "no data
+	// recorded for this cycle" (e.g. tracker wasn't running yet). Preserve the
+	// distinction between "no data" and "real zero" by returning nil in that
+	// case; the text formatter renders it as n/a and JSON serialises it as null.
+	tprAvailable := totalTPR.Valid
+	mwiAvailable := botsMax.Valid
+
+	asValue := func(v sql.NullInt64, available bool) interface{} {
+		if !available || !v.Valid {
+			return nil
+		}
+		return int(v.Int64)
+	}
+
+	return map[string]interface{}{
+		"label":             c.Label,
+		"label_display":     display,
+		"start":             c.Start.Format(time.RFC3339),
+		"end":               c.End.Format(time.RFC3339),
+		"in_progress":       c.InProgress,
+		"tpr_available":     tprAvailable,
+		"mwi_available":     mwiAvailable,
+		"total_tpr":         asValue(totalTPR, tprAvailable),
+		"applications":      asValue(appTPR, tprAvailable),
+		"kubernetes":        asValue(kubeTPR, tprAvailable),
+		"databases":         asValue(dbTPR, tprAvailable),
+		"windows_desktops":  asValue(windowsTPR, tprAvailable),
+		"nodes":             asValue(nodeTPR, tprAvailable),
+		"bots":              asValue(botsMax, mwiAvailable),
+		"bot_instances":     asValue(instMax, mwiAvailable),
+		"spiffe_ids_issued": asValue(spiffeSum, mwiAvailable),
 	}
 }
 


### PR DESCRIPTION
Teleport's Usage History view groups activity into cycles anchored to a
customer-specific day of month (e.g. "7 May - 6 Jun"), not the rolling
30-day window the scripts produced before. Adds a -billing-day flag
(1-31) and a -cycles flag to both scripts so their output can be
compared row-for-row against the portal.

MAU buckets audit events by cycle and emits a per-cycle summary table
plus per-cycle ZTA/IG detail. TPR aggregates from the SQLite history
(MAX per snapshot column, SUM for SPIFFE issuance) and renders n/a for
cycles that pre-date the tracker's first run, since resource counts
can't be reconstructed retroactively from the audit log. Without
-billing-day the original rolling-window output is preserved.

Also adds CLAUDE.md documenting the two-binary-one-package structure
and run.sh's API-version-rewriting behavior, both of which trip up
anyone new to the repo.
