### PR TITLE
feat(templates): conference event preset + canonical demo RBAC

### DIFF
--- a/templates/teleport-terraform/.gitignore
+++ b/templates/teleport-terraform/.gitignore
@@ -11,6 +11,10 @@ crash.*.log
 # Local variable overrides — keep credentials and personal values out of git
 *.tfvars
 *.tfvars.json
+# ...but event presets are shared, credential-free config and MUST be tracked.
+# Black Hat 2026 lesson: the booth preset lived only on one laptop for a month
+# because this rule silently hid it.
+!profiles/presets/*.tfvars
 
 # CLI configuration traces
 terraform.rc

--- a/templates/teleport-terraform/modules/demo-rbac/README.md
+++ b/templates/teleport-terraform/modules/demo-rbac/README.md
@@ -1,18 +1,21 @@
 # demo-rbac
 
-Per-profile Teleport RBAC for demo narratives: a dev role, an access-request (JIT) pair, and a local demo user — generated from the profile's own `env`/`team` variables so the role labels always match the resources the profile deploys.
+Per-profile Teleport RBAC for demo narratives: a dev role, a requestable JIT role trio (staging / prod / prod-with-MFA), the requester/reviewer pair, an optional policy auto-approval rule, and a local demo user — generated from the profile's own `env`/`team` variables so the role labels always match the resources the profile deploys.
 
-**How it differs from `modules/teleport-rbac`:** that module is the deploy-once, cluster-canonical role set managed from `control-plane/`; its names are fixed and its labels are static. This module is instantiated *per profile*, prefixes every role name with `name_prefix` (so concurrent SEs on one cluster don't collide), and is destroyed with the profile.
+**How it differs from `modules/teleport-rbac`:** that module is the deploy-once, cluster-canonical role set managed from `control-plane/`; its names are fixed and its labels are static. This module is instantiated *per profile*, prefixes every role name with `name_prefix` (so concurrent SEs on one cluster don't collide), and is destroyed with the profile. On a dedicated cluster (e.g. an event environment), set `name_prefix = ""` for the canonical unprefixed names the published demo docs use.
 
 ## What It Creates
 
 | Resource | Name | Purpose |
 |---|---|---|
 | `teleport_role` | `<prefix>-dev-access` | Standing access to everything labeled `env=<env>, team=<team>` (SSH, DBs, apps, desktops, MCP) |
-| `teleport_role` | `<prefix>-prod-readonly` | Access to `env=<prod_env>` nodes — only via approved access request. Skipped when `prod_env` is null. |
-| `teleport_role` | `<prefix>-dev-requester` | Can request `<prefix>-prod-readonly` (max duration = `request_max_duration`, default 1h) |
-| `teleport_role` | `<prefix>-prod-reviewer` | Can approve those requests — grant this to the SE (approver persona) |
-| `teleport_user` | `bob` (configurable) | Local user holding dev-access + dev-requester: the developer persona |
+| `teleport_role` | `<prefix>-staging-access` | Requestable elevation over the `env=<env>` resources — the auto-approve target. Skipped when `prod_env` is null. |
+| `teleport_role` | `<prefix>-prod-access` | Access to `env=<prod_env>` nodes — only via approved access request. Skipped when `prod_env` is null. |
+| `teleport_role` | `<prefix>-prod-access-mfa` | Same as prod-access plus per-session MFA (`require_session_mfa = 1`, webauthn). Skipped when `prod_env` is null. |
+| `teleport_role` | `<prefix>-requester` | Can request the trio above (max duration = `request_max_duration`, default 1h). Named `demo-requester` when unprefixed (the `requester` preset exists). |
+| `teleport_role` | `<prefix>-reviewer` | Can approve those requests — grant this to the SE (approver persona). Named `demo-reviewer` when unprefixed. |
+| `teleport_access_monitoring_rule` | `<prefix>-auto-approve-staging` | Auto-approves staging-access requests whose reason contains `auto_approve_reason` (builtin integration). Created only when `auto_approve_reason` is set. |
+| `teleport_user` | `bob` (configurable) | Local user holding dev-access + requester: the developer persona |
 
 ## Usage
 
@@ -20,10 +23,12 @@ Per-profile Teleport RBAC for demo narratives: a dev role, an access-request (JI
 module "demo_rbac" {
   source = "../../modules/demo-rbac"
 
-  name_prefix = local.user_prefix   # e.g. "chris"
+  name_prefix = local.user_prefix   # e.g. "chris"; "" = canonical unprefixed names
   env         = var.env             # matches the labels on deployed resources
   prod_env    = var.prod_env        # omit / null to skip the request flow
   team        = var.team
+
+  auto_approve_reason = "authorized job" # optional: policy-approve staging requests
 }
 ```
 
@@ -40,9 +45,9 @@ tsh login --proxy=<proxy>:443 --user=bob --auth=local
 
 ## The Approver Side
 
-The SE approves requests as themselves. That requires holding `<prefix>-prod-reviewer`:
+Staging requests approve themselves when `auto_approve_reason` is set. Prod requests need a human: the SE approves as themselves, which requires holding `<prefix>-reviewer` (`demo-reviewer` when unprefixed):
 
-- **Local admin user:** `tctl users update <you> --set-roles=<existing roles>,<prefix>-prod-reviewer`
+- **Local admin user:** `tctl users update <you> --set-roles=<existing roles>,<prefix>-reviewer`
 - **SSO user:** add the role through your connector's `attributes_to_roles` or an access list — SSO role sets can't be edited with `tctl users update`.
 
 ## Notes

--- a/templates/teleport-terraform/modules/demo-rbac/main.tf
+++ b/templates/teleport-terraform/modules/demo-rbac/main.tf
@@ -5,16 +5,30 @@
 # needs, generated from the profile's own env/team variables so the labels
 # always match the deployed resources.
 #
-# All role names are prefixed with var.name_prefix so two SEs can deploy the
-# same profile on one cluster without colliding (the demo user name is not
-# prefixed by default — override demo_user_name on shared clusters).
+# Role names are prefixed with var.name_prefix so two SEs can deploy the same
+# profile on one cluster without colliding. On a dedicated cluster (event or
+# canonical deployment) set name_prefix = "" to get the unprefixed names the
+# published demo docs use: dev-access, staging-access, prod-access,
+# prod-access-mfa. The requester/reviewer pair keeps a "demo-" prefix when
+# unprefixed because the `requester` and `reviewer` preset roles already
+# exist on every cluster.
+#
+# The JIT trio (created with the prod flow):
+#   staging-access   requestable, auto-approved by policy when
+#                    auto_approve_reason is set (access_monitoring_rule)
+#   prod-access      requestable, human approval required
+#   prod-access-mfa  requestable, human approval + per-session MFA
 #
 # Unlike modules/teleport-rbac (the deploy-once, cluster-canonical role set
 # managed from control-plane), this module is instantiated per profile and
 # torn down with it.
 #
-# Numeric enums (Terraform provider uses proto enum ints):
-#   create_host_user_mode:  0 = off  1 = keep  2 = drop
+# Numeric enums (Terraform provider uses proto enum ints — verify against the
+# provider schema, the values are NOT sequential/obvious):
+#   create_host_user_mode:  0 = unspecified  1 = OFF  3 = keep  4 = insecure-drop
+#                           (2 = drop, removed in v15+)
+#   require_session_mfa:    0 = off  1 = per-session webauthn
+#                           2..5 = hardware-key variants (require YubiKeys)
 ##################################################################################
 
 terraform {
@@ -28,6 +42,14 @@ terraform {
 
 locals {
   create_prod = var.prod_env != null
+
+  # "" -> unprefixed canonical names; anything else -> "<prefix>-"
+  p = var.name_prefix == "" ? "" : "${var.name_prefix}-"
+
+  # requester/reviewer collide with cluster preset roles when unprefixed
+  dp = var.name_prefix == "" ? "demo-" : "${var.name_prefix}-"
+
+  creator = var.name_prefix == "" ? "demo-rbac" : var.name_prefix
 }
 
 ##################################################################################
@@ -38,15 +60,15 @@ resource "teleport_role" "dev_access" {
   version = "v7"
 
   metadata = {
-    name        = "${var.name_prefix}-dev-access"
-    description = "Demo: standing access to ${var.env}-labeled resources (${var.name_prefix})"
+    name        = "${local.p}dev-access"
+    description = "Demo: standing access to ${var.env}-labeled resources"
   }
 
   spec = {
     options = {
       max_session_ttl                = "8h0m0s"
       enhanced_recording             = ["command", "network"]
-      create_host_user_mode          = 1
+      create_host_user_mode          = 3
       create_host_user_default_shell = "/bin/bash"
       create_db_user                 = false
       create_desktop_user            = true
@@ -70,7 +92,7 @@ resource "teleport_role" "dev_access" {
       host_groups    = ["wheel"]
       logins         = var.logins
       mcp = {
-        tools = ["*"]
+        tools = var.mcp_tools
       }
       node_labels = {
         env  = [var.env]
@@ -84,30 +106,145 @@ resource "teleport_role" "dev_access" {
         env  = [var.env]
         team = [var.team]
       }
-      windows_desktop_logins = var.logins
+      # Persona-named Windows login first ({{internal.windows_logins}} resolves to
+      # the user's own trait, e.g. "bob"), generic logins as fallback. With
+      # create_desktop_user, first RDP login creates the local Windows account
+      # under the persona's name: the identity story on the Windows side.
+      windows_desktop_logins = concat(["{{internal.windows_logins}}"], var.logins)
     }
   }
 }
 
 ##################################################################################
-# PROD READONLY — only reachable through an approved access request
+# MCP READ-WRITE — full MCP toolset on one app, for the identity-contrast beat.
+# Teleport filters denied tools out of the MCP tools/list response, so a client
+# holding only the dev role's read-only allowlist is never even offered
+# write_file. Grant this role to one identity (e.g. the SEs via connector
+# mapping) and List Tools side by side with the persona: same server, same
+# request, different toolset per identity.
 ##################################################################################
 
-resource "teleport_role" "prod_readonly" {
+resource "teleport_role" "mcp_rw" {
+  count   = var.mcp_rw_app == null ? 0 : 1
+  version = "v7"
+
+  metadata = {
+    name        = "${local.p}${var.mcp_rw_app}-rw"
+    description = "Demo: all MCP tools on the ${var.mcp_rw_app} app (contrast with ${local.p}dev-access's read-only allowlist)"
+  }
+
+  spec = {
+    allow = {
+      app_labels = {
+        "teleport.dev/app" = [var.mcp_rw_app]
+      }
+      mcp = {
+        tools = ["*"]
+      }
+    }
+  }
+}
+
+##################################################################################
+# STAGING ACCESS — requestable elevation over the dev-labeled resources.
+# The auto-approve access_monitoring_rule below targets this role only, so
+# the booth flow is: staging approves by policy, prod needs a human.
+##################################################################################
+
+resource "teleport_role" "staging_access" {
   count   = local.create_prod ? 1 : 0
   version = "v7"
 
   metadata = {
-    name        = "${var.name_prefix}-prod-readonly"
-    description = "Demo: access to ${var.prod_env}-labeled resources, granted only via access request (${var.name_prefix})"
+    name        = "${local.p}staging-access"
+    description = "Demo: requestable elevated access to ${var.env}-labeled resources (auto-approved by policy when the reason matches)"
+  }
+
+  spec = {
+    options = {
+      max_session_ttl                = "4h0m0s"
+      enhanced_recording             = ["command", "network"]
+      create_host_user_mode          = 3
+      create_host_user_default_shell = "/bin/bash"
+      create_db_user                 = false
+    }
+
+    allow = {
+      app_labels = {
+        env  = [var.env]
+        team = [var.team]
+      }
+      db_labels = {
+        env  = [var.env]
+        team = [var.team]
+      }
+      db_names    = ["*"]
+      db_users    = var.db_users
+      host_groups = ["wheel"]
+      logins      = var.logins
+      node_labels = {
+        env  = [var.env]
+        team = [var.team]
+      }
+      rules = [
+        { resources = ["event"], verbs = ["list", "read"] },
+        { resources = ["session"], verbs = ["read", "list"] }
+      ]
+    }
+  }
+}
+
+##################################################################################
+# PROD ACCESS — only reachable through an approved access request
+##################################################################################
+
+resource "teleport_role" "prod_access" {
+  count   = local.create_prod ? 1 : 0
+  version = "v7"
+
+  metadata = {
+    name        = "${local.p}prod-access"
+    description = "Demo: access to ${var.prod_env}-labeled resources, granted only via an approved access request"
   }
 
   spec = {
     options = {
       max_session_ttl       = "4h0m0s"
       enhanced_recording    = ["command", "network"]
-      create_host_user_mode = 0
+      create_host_user_mode = 1
       create_db_user        = false
+    }
+
+    allow = {
+      logins = var.logins
+      node_labels = {
+        env  = [var.prod_env]
+        team = [var.team]
+      }
+      rules = [
+        { resources = ["event"], verbs = ["list", "read"] },
+        { resources = ["session"], verbs = ["read", "list"] }
+      ]
+    }
+  }
+}
+
+resource "teleport_role" "prod_access_mfa" {
+  count   = local.create_prod ? 1 : 0
+  version = "v7"
+
+  metadata = {
+    name        = "${local.p}prod-access-mfa"
+    description = "Demo: ${var.prod_env} access via access request, with per-session MFA re-verification"
+  }
+
+  spec = {
+    options = {
+      max_session_ttl       = "1h0m0s"
+      enhanced_recording    = ["command", "network"]
+      create_host_user_mode = 1
+      create_db_user        = false
+      require_session_mfa   = 1
     }
 
     allow = {
@@ -128,41 +265,101 @@ resource "teleport_role" "prod_readonly" {
 # REQUESTER / REVIEWER — the JIT access-request pair
 ##################################################################################
 
-resource "teleport_role" "dev_requester" {
+resource "teleport_role" "requester" {
   count   = local.create_prod ? 1 : 0
   version = "v7"
 
   metadata = {
-    name        = "${var.name_prefix}-dev-requester"
-    description = "Demo: can request ${var.name_prefix}-prod-readonly (${var.name_prefix})"
+    name        = "${local.dp}requester"
+    description = "Demo: can request ${local.p}staging-access, ${local.p}prod-access, ${local.p}prod-access-mfa"
   }
 
   spec = {
     allow = {
       request = {
-        roles           = [teleport_role.prod_readonly[0].metadata.name]
-        search_as_roles = [teleport_role.prod_readonly[0].metadata.name]
-        max_duration    = var.request_max_duration
+        roles = [
+          teleport_role.staging_access[0].metadata.name,
+          teleport_role.prod_access[0].metadata.name,
+          teleport_role.prod_access_mfa[0].metadata.name,
+        ]
+        search_as_roles = [
+          teleport_role.staging_access[0].metadata.name,
+          teleport_role.prod_access[0].metadata.name,
+          teleport_role.prod_access_mfa[0].metadata.name,
+        ]
+        max_duration = var.request_max_duration
       }
     }
   }
 }
 
-resource "teleport_role" "prod_reviewer" {
+resource "teleport_role" "reviewer" {
   count   = local.create_prod ? 1 : 0
   version = "v7"
 
   metadata = {
-    name        = "${var.name_prefix}-prod-reviewer"
-    description = "Demo: can approve requests for ${var.name_prefix}-prod-readonly (${var.name_prefix})"
+    name        = "${local.dp}reviewer"
+    description = "Demo: can approve requests for the ${local.p}staging/prod access roles"
   }
 
   spec = {
     allow = {
       review_requests = {
-        roles            = [teleport_role.prod_readonly[0].metadata.name]
-        preview_as_roles = [teleport_role.prod_readonly[0].metadata.name]
+        roles = [
+          teleport_role.staging_access[0].metadata.name,
+          teleport_role.prod_access[0].metadata.name,
+          teleport_role.prod_access_mfa[0].metadata.name,
+        ]
+        preview_as_roles = [
+          teleport_role.staging_access[0].metadata.name,
+          teleport_role.prod_access[0].metadata.name,
+          teleport_role.prod_access_mfa[0].metadata.name,
+        ]
       }
+      # Live-join the demo personas' SSH sessions (observer or moderator) —
+      # the "watch, then lock" beat. Matches sessions hosted by holders of
+      # the demo access roles.
+      join_sessions = [{
+        name = "join-demo-sessions"
+        roles = [
+          teleport_role.dev_access.metadata.name,
+          teleport_role.staging_access[0].metadata.name,
+          teleport_role.prod_access[0].metadata.name,
+          teleport_role.prod_access_mfa[0].metadata.name,
+        ]
+        kinds = ["ssh"]
+        modes = ["observer", "moderator"]
+      }]
+    }
+  }
+}
+
+##################################################################################
+# AUTO-APPROVE — policy-driven review: staging-access requests whose reason
+# contains var.auto_approve_reason are approved by the builtin integration.
+# Prod roles always require a human review.
+##################################################################################
+
+resource "teleport_access_monitoring_rule" "auto_approve_staging" {
+  count   = local.create_prod && var.auto_approve_reason != null ? 1 : 0
+  version = "v1"
+
+  metadata = {
+    name        = "${local.dp}auto-approve-staging"
+    description = "Demo: auto-approve ${local.p}staging-access requests when the reason contains \"${var.auto_approve_reason}\""
+  }
+
+  spec = {
+    subjects = ["access_request"]
+    # Exact-match on the reason: request_reason is a string, and the predicate
+    # language's contains()/regexp.match() only operate on sets (set()-wrapping
+    # passes validation but silently never matches at evaluation — verified on
+    # v18.10). The request reason must therefore EQUAL auto_approve_reason.
+    condition     = "access_request.spec.roles.contains(\"${teleport_role.staging_access[0].metadata.name}\") && access_request.spec.request_reason == \"${var.auto_approve_reason}\""
+    desired_state = "reviewed"
+    automatic_review = {
+      integration = "builtin"
+      decision    = "APPROVED"
     }
   }
 }
@@ -182,16 +379,48 @@ resource "teleport_user" "demo_user" {
 
   metadata = {
     name        = var.demo_user_name
-    description = "Demo developer persona for ${var.name_prefix} (local user)"
+    description = "Demo developer persona (local user)"
     labels = {
-      "teleport.dev/creator" = var.name_prefix
+      "teleport.dev/creator" = local.creator
     }
   }
 
   spec = {
     roles = concat(
       [teleport_role.dev_access.metadata.name],
-      local.create_prod ? [teleport_role.dev_requester[0].metadata.name] : []
+      local.create_prod ? [teleport_role.requester[0].metadata.name] : [],
+      var.extra_role_names
     )
+    # Windows RDP login named after the persona (consumed by the dev role's
+    # {{internal.windows_logins}} template).
+    traits = {
+      windows_logins = [var.demo_user_name]
+    }
+  }
+}
+
+# One persona per demo workstation: same roles as the primary demo user, so
+# concurrent demos don't share sessions, requests, or the lock blast radius.
+resource "teleport_user" "extra_demo_users" {
+  for_each = var.create_demo_user ? toset(var.extra_demo_user_names) : toset([])
+  version  = "v2"
+
+  metadata = {
+    name        = each.value
+    description = "Demo developer persona (local user)"
+    labels = {
+      "teleport.dev/creator" = local.creator
+    }
+  }
+
+  spec = {
+    roles = concat(
+      [teleport_role.dev_access.metadata.name],
+      local.create_prod ? [teleport_role.requester[0].metadata.name] : [],
+      var.extra_role_names
+    )
+    traits = {
+      windows_logins = [each.value]
+    }
   }
 }

--- a/templates/teleport-terraform/modules/demo-rbac/outputs.tf
+++ b/templates/teleport-terraform/modules/demo-rbac/outputs.tf
@@ -1,37 +1,62 @@
 output "dev_access_role" {
-  description = "Name of the dev access role"
+  description = "Name of the standing dev access role"
   value       = teleport_role.dev_access.metadata.name
 }
 
-output "prod_readonly_role" {
-  description = "Name of the prod readonly role (null when prod_env is not set)"
-  value       = var.prod_env != null ? teleport_role.prod_readonly[0].metadata.name : null
+output "staging_access_role" {
+  description = "Name of the requestable staging role (null when prod_env is not set)"
+  value       = try(teleport_role.staging_access[0].metadata.name, null)
 }
 
-output "dev_requester_role" {
+output "prod_access_role" {
+  description = "Name of the requestable prod role (null when prod_env is not set)"
+  value       = try(teleport_role.prod_access[0].metadata.name, null)
+}
+
+output "prod_access_mfa_role" {
+  description = "Name of the requestable prod role with per-session MFA (null when prod_env is not set)"
+  value       = try(teleport_role.prod_access_mfa[0].metadata.name, null)
+}
+
+output "requester_role" {
   description = "Name of the requester role (null when prod_env is not set)"
-  value       = var.prod_env != null ? teleport_role.dev_requester[0].metadata.name : null
+  value       = try(teleport_role.requester[0].metadata.name, null)
 }
 
-output "prod_reviewer_role" {
+output "reviewer_role" {
   description = "Name of the reviewer role (null when prod_env is not set)"
-  value       = var.prod_env != null ? teleport_role.prod_reviewer[0].metadata.name : null
+  value       = try(teleport_role.reviewer[0].metadata.name, null)
+}
+
+output "auto_approve_rule" {
+  description = "Name of the auto-approve access monitoring rule (null unless prod_env and auto_approve_reason are set)"
+  value       = try(teleport_access_monitoring_rule.auto_approve_staging[0].metadata.name, null)
 }
 
 output "demo_user_name" {
-  description = "Name of the local demo user (null when create_demo_user is false)"
+  description = "Name of the primary local demo user (null when create_demo_user is false)"
   value       = var.create_demo_user ? teleport_user.demo_user[0].metadata.name : null
 }
 
+output "demo_user_names" {
+  description = "All local demo users (primary + per-workstation extras)"
+  value       = var.create_demo_user ? concat([var.demo_user_name], var.extra_demo_user_names) : []
+}
+
 output "demo_user_setup" {
-  description = "One-time activation steps for the demo user"
-  value = var.create_demo_user ? join("\n", compact([
-    "# Activate ${var.demo_user_name} (one time): generates a reset link to set password + MFA",
-    "tctl users reset ${var.demo_user_name}",
-    "# Log in as ${var.demo_user_name} (local auth, even on SSO-default clusters):",
-    "tsh login --proxy=<proxy>:443 --user=${var.demo_user_name} --auth=local",
-    var.prod_env != null ? "# Approving requests requires the ${var.name_prefix}-prod-reviewer role — grant it to yourself once:" : "",
-    var.prod_env != null ? "#   tctl users update <your-username> --set-roles=$(tctl get user/<your-username> --format=json | jq -r '.[0].spec.roles | join(\",\")'),${var.name_prefix}-prod-reviewer" : "",
-    var.prod_env != null ? "#   (SSO users: add the role via your connector mapping or an access list instead)" : "",
-  ])) : null
+  description = "One-time activation steps for the demo user(s)"
+  value = var.create_demo_user ? join("\n", compact(concat(
+    [for u in concat([var.demo_user_name], var.extra_demo_user_names) :
+    "tctl users reset ${u}    # one-time activation: reset link sets password + MFA (enroll MFA on that user's workstation)"],
+    [
+      "# Log in (local auth, even on SSO-default clusters):",
+      "tsh login --proxy=<proxy>:443 --user=${var.demo_user_name} --auth=local",
+      local.create_prod ? "# JIT flow — staging approves by policy, prod needs a human review:" : "",
+      local.create_prod && var.auto_approve_reason != null ? "#   tsh request create --roles=${try(teleport_role.staging_access[0].metadata.name, "")} --reason='${var.auto_approve_reason}'   # auto-approved" : "",
+      local.create_prod ? "#   tsh request create --roles=${try(teleport_role.prod_access[0].metadata.name, "")} --reason='need prod'   # waits for a reviewer" : "",
+      local.create_prod ? "# Approving prod requests requires the ${try(teleport_role.reviewer[0].metadata.name, "")} role — grant it to yourself once:" : "",
+      local.create_prod ? "#   tctl users update <your-username> --set-roles=<existing-roles>,${try(teleport_role.reviewer[0].metadata.name, "")}" : "",
+      local.create_prod ? "#   (SSO users: add the role via your connector mapping or an access list instead)" : "",
+    ]
+  ))) : null
 }

--- a/templates/teleport-terraform/modules/demo-rbac/variables.tf
+++ b/templates/teleport-terraform/modules/demo-rbac/variables.tf
@@ -1,6 +1,12 @@
 variable "name_prefix" {
-  description = "Prefix for all Teleport role names (e.g. the SE's username) so concurrent deployments on a shared cluster don't collide"
+  description = "Prefix for all Teleport role names (e.g. the SE's username) so concurrent deployments on a shared cluster don't collide. Set to \"\" on a dedicated cluster for the canonical unprefixed names (dev-access, staging-access, prod-access, prod-access-mfa; requester/reviewer become demo-requester/demo-reviewer to avoid the cluster presets)."
   type        = string
+}
+
+variable "auto_approve_reason" {
+  description = "When set, creates an access_monitoring_rule that auto-approves staging-access requests whose reason exactly equals this phrase (builtin integration; the predicate language has no substring match for strings). null disables auto-approval. Only applies when prod_env is set."
+  type        = string
+  default     = null
 }
 
 variable "env" {
@@ -31,6 +37,12 @@ variable "demo_user_name" {
   default     = "bob"
 }
 
+variable "extra_demo_user_names" {
+  description = "Additional local demo users with the same roles as the primary one — one persona per demo workstation so concurrent demos (and the lock beat) don't collide. Each needs its own one-time activation."
+  type        = list(string)
+  default     = []
+}
+
 variable "logins" {
   description = "OS logins the roles allow"
   type        = list(string)
@@ -41,6 +53,24 @@ variable "db_users" {
   description = "Database users the dev role allows (must exist on the demo databases)"
   type        = list(string)
   default     = ["reader", "writer"]
+}
+
+variable "mcp_tools" {
+  description = "MCP tool allowlist for the dev role (glob patterns). Default allows all; set read-only patterns (e.g. [\"read_*\", \"list_*\"]) to demo AI tool-call denial + audit."
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "mcp_rw_app" {
+  description = "When set (e.g. \"mcp-filesystem\"), also create <prefix><value>-rw granting all MCP tools on apps labeled teleport.dev/app=<value>. Grant it to one identity and not another for the MCP Inspector list-tools contrast: same server, different toolset per identity."
+  type        = string
+  default     = null
+}
+
+variable "extra_role_names" {
+  description = "Names of roles created outside this module to also attach to the demo users — e.g. linux-desktop-access, which lives in modules/linux-desktop because its role fields need the v19 provider."
+  type        = list(string)
+  default     = []
 }
 
 variable "request_max_duration" {

--- a/templates/teleport-terraform/modules/linux-desktop/README.md
+++ b/templates/teleport-terraform/modules/linux-desktop/README.md
@@ -1,0 +1,92 @@
+# Linux Desktop Module
+
+Linux Desktop Access (Teleport 19+): one Ubuntu 24.04 host running `linux_desktop_service` with an Xfce desktop rendered through Xvfb. Unlike Windows desktop access (which pairs `windows-instance` with `desktop-service` as an RDP proxy), the service runs **on the desktop host itself** — Teleport starts a virtual X11 display per session and launches the desktop environment inside it. Outbound reverse tunnel only; no inbound ports.
+
+## Overview
+
+- **Use Case:** browser-based access to a full Linux desktop, with session recording
+- **Teleport Features:** `linux_desktop_service`, xsession discovery from `/usr/share/xsessions`, session recording, `linux_desktop_labels` / `linux_desktop_logins` RBAC
+- **Infrastructure:** Ubuntu 24.04 instance (Xfce + Xvfb), Teleport installed from the proxy's install script
+
+## Requirements
+
+- **Teleport 19+** cluster and the **v19 Terraform provider**. The `LinuxDesktop` token role and the `linux_desktop_*` role fields don't exist in the 18.x provider — it rejects them client-side. That's also why this module owns its own access role instead of `modules/demo-rbac` (18.x-pinned); fold the role into demo-rbac when the repo moves to the 19 GA provider.
+- Ubuntu AMI. AL2023 ships no desktop environment packages, so this module doesn't use the shared `data.aws_ami.linux`.
+
+## Usage
+
+```hcl
+module "linux_desktop" {
+  source = "../modules/linux-desktop"
+
+  env           = "dev"
+  team          = "platform"
+  user          = "engineer@company.com"
+  proxy_address = "teleport.company.com"
+
+  ami_id             = data.aws_ami.ubuntu.id
+  subnet_id          = module.network.subnet_id
+  security_group_ids = [module.network.security_group_id]
+
+  # Created on the host AND allowed by the access role — the service does not
+  # auto-create users (no create_desktop_user equivalent for Linux).
+  desktop_logins = ["bob", "ubuntu"]
+  name_prefix    = "chris" # role becomes chris-linux-desktop-access
+}
+```
+
+## What It Creates
+
+- **EC2 instance** — Ubuntu 24.04, Xfce + Xvfb, Teleport `linux_desktop_service` + `ssh_service` (both labeled `env`/`team`; SSH gives you a debug path onto the box)
+- **Provision token** — roles `["LinuxDesktop", "Node"]`, 8h expiry
+- **Role `<prefix>linux-desktop-access`** (optional, `create_access_role`) — `linux_desktop_labels` matching `env`/`team`, `linux_desktop_logins` = `desktop_logins`
+
+## Session discovery and filtering
+
+Teleport offers one session per `.desktop` file in `/usr/share/xsessions` (this module installs only Xfce, so one entry). To filter on multi-DE hosts, set `xsessions_included` / `xsessions_excluded` — regexes matched against the filename without `.desktop`, e.g. `included = "^xfce$"`.
+
+## Demo commands
+
+Desktops are web UI / Teleport Connect only (no tsh):
+
+```
+https://<proxy>/web/desktops        # Connect → pick login → live Xfce session
+tsh ssh ubuntu@dev-linux-desktop    # debug path onto the same host
+tsh recordings ls                   # desktop sessions are recorded like everything else
+```
+
+## Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `env`, `team`, `user`, `proxy_address` | The usual profile plumbing | — |
+| `ami_id` | Ubuntu 24.04 AMI | — |
+| `instance_type` | Xfce-in-Xvfb wants memory | `t3.medium` |
+| `subnet_id`, `security_group_ids`, `tags` | Placement | — |
+| `desktop_logins` | Host users to create + allow in the role | `["ubuntu"]` |
+| `create_access_role` | Create `<prefix>linux-desktop-access` | `true` |
+| `name_prefix` | Role-name prefix (`""` = canonical unprefixed) | `""` |
+| `xsessions_included` / `xsessions_excluded` | Session filter regexes | `""` (off) |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `instance_id`, `private_ip` | The host |
+| `hostname` | Name the desktop registers under (`<env>-linux-desktop`) |
+| `access_role_name` | Role to grant users/personas (null when `create_access_role = false`) |
+
+## Troubleshooting
+
+```bash
+tsh ssh ubuntu@dev-linux-desktop
+sudo journalctl -fu teleport            # registration + session launch logs
+which Xvfb                              # must be in PATH for the service
+ls /usr/share/xsessions/                # what Teleport discovers (expect xfce.desktop)
+id bob                                  # desktop logins must exist on the host
+tctl get linux_desktop                  # confirm registration
+```
+
+- **Desktop not listed:** wait for cloud-init to finish (`cloud-init status`), Xfce is a few GB of packages.
+- **Session fails immediately:** the chosen login doesn't exist on the host — check `desktop_logins`.
+- **Role rejected at apply:** you're on the 18.x provider; this module needs v19.

--- a/templates/teleport-terraform/modules/linux-desktop/main.tf
+++ b/templates/teleport-terraform/modules/linux-desktop/main.tf
@@ -1,0 +1,130 @@
+##################################################################################
+# modules/linux-desktop/main.tf
+#
+# Linux Desktop Access (Teleport 19+): one Ubuntu host running linux_desktop_service.
+# Unlike Windows desktop access (windows-instance + desktop-service pair), the
+# service runs ON the desktop host itself — Teleport starts a virtual X11 display
+# with Xvfb and launches an Xfce session inside it. Outbound reverse tunnel only,
+# no inbound ports.
+#
+# The service does NOT create host users (session setup fails user.Lookup if the
+# login doesn't exist), so userdata pre-creates every login in var.desktop_logins.
+#
+# This module also owns the linux-desktop-access role instead of modules/demo-rbac:
+# the linux_desktop_labels / linux_desktop_logins role fields and the LinuxDesktop
+# token role exist only in the v19 provider (the 18.x provider rejects both
+# client-side). Fold the role into demo-rbac once the pinned provider is 19 GA.
+##################################################################################
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    # v19 staging provider — must match the address the profiles root pins.
+    # LinuxDesktop token roles and linux_desktop_* role fields are 19-only.
+    teleport = {
+      source = "terraform-staging.releases.development.teleport.dev/gravitational/teleport"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+locals {
+  user = lower(split("@", var.user)[0])
+
+  # "" -> unprefixed canonical name; anything else -> "<prefix>-"
+  p = var.name_prefix == "" ? "" : "${var.name_prefix}-"
+}
+
+resource "random_string" "token" {
+  length  = 32
+  special = false
+}
+
+resource "teleport_provision_token" "linux_desktop" {
+  version = "v2"
+  spec = {
+    roles = ["LinuxDesktop", "Node"]
+    name  = random_string.token.result
+  }
+  metadata = {
+    expires = timeadd(timestamp(), "8h")
+  }
+  # timestamp() changes on every plan, causing perpetual drift noise.
+  # The token only needs to live long enough for the instance to boot and register.
+  lifecycle {
+    ignore_changes = [metadata]
+  }
+}
+
+resource "aws_instance" "linux_desktop" {
+  # Demo hosts keep the AMI they were created with — data.aws_ami uses
+  # most_recent, and a new upstream image must not replace healthy
+  # instances on the next apply (e.g. mid-event).
+  lifecycle {
+    ignore_changes = [ami]
+  }
+
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  subnet_id     = var.subnet_id
+  # Registers via outbound reverse tunnel — no public IP needed.
+  associate_public_ip_address = null
+  vpc_security_group_ids      = var.security_group_ids
+
+  user_data = templatefile("${path.module}/userdata.tpl", {
+    name               = "${var.env}-linux-desktop"
+    token              = teleport_provision_token.linux_desktop.metadata.name
+    proxy_address      = var.proxy_address
+    env                = var.env
+    team               = var.team
+    desktop_logins     = join(" ", var.desktop_logins)
+    xsessions_included = var.xsessions_included
+    xsessions_excluded = var.xsessions_excluded
+  })
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    # Xfce + Xvfb + fonts land around 3-4 GB of packages on top of the base image.
+    volume_size           = 30
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = merge(var.tags, {
+    Name = "${local.user}-${var.env}-linux-desktop"
+  })
+}
+
+##################################################################################
+# LINUX DESKTOP ACCESS — standing access to this profile's linux desktops.
+# Persona logins first (userdata created them on the host), generic fallback last.
+##################################################################################
+
+resource "teleport_role" "linux_desktop_access" {
+  count   = var.create_access_role ? 1 : 0
+  version = "v7"
+
+  metadata = {
+    name        = "${local.p}linux-desktop-access"
+    description = "Demo: access to ${var.env}-labeled Linux desktops"
+  }
+
+  spec = {
+    allow = {
+      linux_desktop_labels = {
+        env  = [var.env]
+        team = [var.team]
+      }
+      linux_desktop_logins = var.desktop_logins
+    }
+  }
+}

--- a/templates/teleport-terraform/modules/linux-desktop/outputs.tf
+++ b/templates/teleport-terraform/modules/linux-desktop/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "EC2 instance ID of the Linux desktop host"
+  value       = aws_instance.linux_desktop.id
+}
+
+output "private_ip" {
+  description = "Private IP of the Linux desktop host"
+  value       = aws_instance.linux_desktop.private_ip
+}
+
+output "hostname" {
+  description = "Hostname the desktop registers under in Teleport"
+  value       = "${var.env}-linux-desktop"
+}
+
+output "access_role_name" {
+  description = "Name of the linux-desktop-access role (null when create_access_role is false)"
+  value       = var.create_access_role ? teleport_role.linux_desktop_access[0].metadata.name : null
+}

--- a/templates/teleport-terraform/modules/linux-desktop/userdata.tpl
+++ b/templates/teleport-terraform/modules/linux-desktop/userdata.tpl
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euxo pipefail
+
+hostnamectl set-hostname "${name}"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+
+# Xfce desktop + Xvfb (the virtual framebuffer Teleport renders sessions into).
+# xfce4 ships /usr/share/xsessions/xfce.desktop, which is how Teleport discovers
+# the session. No display manager: Teleport launches sessions itself.
+apt-get install -y xfce4 xfce4-terminal xvfb dbus-x11
+
+# Headless box — never try to bring up a graphical login on boot.
+systemctl set-default multi-user.target
+
+# The desktop service does not create host users; every login offered by the
+# access role must already exist (session setup does a user.Lookup).
+for u in ${desktop_logins}; do
+  id "$u" &>/dev/null || useradd -m -s /bin/bash "$u"
+done
+
+# install.sh fetched from the proxy installs the cluster-advertised version via teleport-update
+curl "https://${proxy_address}/scripts/install.sh" | bash
+
+teleport version || true
+which Xvfb
+
+echo "${token}" > /tmp/token
+
+cat <<EOF >/etc/teleport.yaml
+version: v3
+teleport:
+  data_dir: /var/lib/teleport
+  auth_token: /tmp/token
+  proxy_server: ${proxy_address}:443
+  log:
+    output: stderr
+    severity: INFO
+    format:
+      output: json
+linux_desktop_service:
+  enabled: true
+  labels:
+    env: ${env}
+    team: ${team}
+%{ if xsessions_included != "" || xsessions_excluded != "" ~}
+  xsessions:
+%{ if xsessions_included != "" ~}
+    included: "${xsessions_included}"
+%{ endif ~}
+%{ if xsessions_excluded != "" ~}
+    excluded: "${xsessions_excluded}"
+%{ endif ~}
+%{ endif ~}
+ssh_service:
+  enabled: true
+  labels:
+    env: ${env}
+    team: ${team}
+  commands:
+    - name: hostname
+      command: [hostname]
+      period: 1m0s
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+EOF
+
+systemctl enable teleport
+systemctl restart teleport
+
+echo "[INFO] Teleport linux_desktop_service setup complete."

--- a/templates/teleport-terraform/modules/linux-desktop/variables.tf
+++ b/templates/teleport-terraform/modules/linux-desktop/variables.tf
@@ -1,0 +1,77 @@
+variable "env" {
+  description = "Environment tag (e.g., dev, prod)"
+  type        = string
+}
+
+variable "team" {
+  description = "Team label for the desktop and SSH services"
+  type        = string
+  default     = "platform"
+}
+
+variable "user" {
+  description = "Tag value for resource creator"
+  type        = string
+}
+
+variable "proxy_address" {
+  description = "Teleport proxy address (host only, no scheme or port)"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for Ubuntu 24.04 (AL2023 ships no desktop environment packages)"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type — Xfce sessions inside Xvfb want the memory"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "subnet_id" {
+  description = "Subnet ID to launch instance in"
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs"
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Extra AWS tags for the instance"
+  type        = map(string)
+  default     = {}
+}
+
+variable "desktop_logins" {
+  description = "OS logins offered for desktop sessions. Userdata creates each one on the host (the service does not auto-create users), and the access role allows the same list."
+  type        = list(string)
+  default     = ["ubuntu"]
+}
+
+variable "create_access_role" {
+  description = "Create the <prefix>linux-desktop-access role. Lives here rather than modules/demo-rbac because the linux_desktop_* role fields need the v19 provider."
+  type        = bool
+  default     = true
+}
+
+variable "name_prefix" {
+  description = "Prefix for the access role name (e.g. the SE's username) so concurrent deployments on a shared cluster don't collide. Set to \"\" for the canonical unprefixed name (linux-desktop-access)."
+  type        = string
+  default     = ""
+}
+
+variable "xsessions_included" {
+  description = "Regex of xsession names to offer (matched against the .desktop filename, e.g. \"^xfce$\"). Empty = offer everything found in /usr/share/xsessions."
+  type        = string
+  default     = ""
+}
+
+variable "xsessions_excluded" {
+  description = "Regex of xsession names to hide (applied after included). Empty = hide nothing."
+  type        = string
+  default     = ""
+}

--- a/templates/teleport-terraform/profiles/README.md
+++ b/templates/teleport-terraform/profiles/README.md
@@ -8,7 +8,7 @@ All enabled use cases share one VPC, one state file, one `terraform destroy`.
 
 ```bash
 tsh login --proxy=myorg.teleport.sh
-eval $(tctl terraform env)
+eval $(tctl terraform env) # requires the preset Editor role or equivalent permissions to run
 
 export TF_VAR_proxy_address=myorg.teleport.sh
 export TF_VAR_user=you@company.com
@@ -32,7 +32,7 @@ Compose your own by combining flags: `terraform apply -var-file=presets/grafana.
 | `dev-demo` | Developer "day in the life" — Bob + access requests + session locking | ~$5–7/day |
 | `full-platform` | All-up POC — every capability in one deployment | ~$8–12/day |
 | `cloud-native-apps` | Modern cloud shop — Grafana, HTTPBin, RDS IAM auth, AWS Console | ~$3–5/day |
-| `ssh`, `postgres`, `mysql`, `mongodb`, `cassandra`, `rds-mysql`, `grafana`, `httpbin`, `demo-panel`, `aws-console`, `windows`, `mcp`, `ansible` | Single-feature demos | ~$1–2/day each |
+| `ssh`, `postgres`, `mysql`, `mongodb`, `cassandra`, `rds-mysql`, `grafana`, `httpbin`, `demo-panel`, `aws-console`, `windows`, `linux-desktop`, `mcp`, `ansible` | Single-feature demos (`linux-desktop` needs Teleport 19+) | ~$1–2/day each |
 
 Costs assume the default `create_nat_gateway = false` (public subnet with public IPs, inbound blocked by the security group). A NAT gateway adds ~$1/day.
 
@@ -41,13 +41,13 @@ Costs assume the default `create_nat_gateway = false` (public subnet with public
 By default (`create_demo_rbac = true`) every deployment also creates the roles its narrative needs — prefixed with your username (e.g. `chris-dev-access`) so concurrent SEs on one cluster don't collide — plus a local `bob` user holding the dev role. Two one-time steps after `apply`, both printed in the `demo_user_setup` output:
 
 1. **Activate bob:** `tctl users reset bob` prints a reset link (password + MFA), then `tsh login --user=bob --auth=local` (the `--auth=local` flag matters on SSO-default clusters).
-2. **Approver role** (only when `enable_ssh_prod` is on): approving bob's request requires `<you>-prod-reviewer`. Local admin: `tctl users update <you> --set-roles=<existing>,<you>-prod-reviewer`. SSO user: grant via connector mapping or an access list.
+2. **Approver role** (only when `enable_ssh_prod` is on): approving bob's prod request requires `<you>-reviewer` (`demo-reviewer` when `demo_rbac_role_prefix = ""`). Local admin: `tctl users update <you> --set-roles=<existing>,<you>-reviewer`. SSO user: grant via connector mapping or an access list. Staging requests skip the human when `auto_approve_reason` is set — policy approves them via an access monitoring rule.
 
 Set `create_demo_rbac = false` if your cluster already runs the canonical role set from [`control-plane/cloud/3-rbac`](../control-plane/cloud/3-rbac/) — the request flow then uses `prod-readonly-access`.
 
 ## Demo flow: dev-demo (Developer Day in the Life)
 
-Personas: **Bob** (local user, `<you>-dev-access` + `<you>-dev-requester`) and **Alex** — played by you, with your own login plus `<you>-prod-reviewer`.
+Personas: **Bob** (local user, `<you>-dev-access` + `<you>-requester`) and **Alex** — played by you, with your own login plus `<you>-reviewer`.
 
 1. **Bob logs in — sees only dev resources**
    ```bash
@@ -59,7 +59,7 @@ Personas: **Bob** (local user, `<you>-dev-access` + `<you>-dev-requester`) and *
 4. **App access with JWT** — `tsh apps login grafana-dev`, or open `https://httpbin-dev.<proxy>/headers` and point at `Teleport-Jwt-Assertion` / `X-Forwarded-User`.
 5. **Bob requests prod access**
    ```bash
-   tsh request create --roles=<you>-prod-readonly --reason="need to check prod logs"
+   tsh request create --roles=<you>-prod-access --reason="need to check prod logs"
    ```
 6. **Alex approves** — Web UI, or `tsh request review <request-id> --approve --reason="ok"` (Slack notification requires the Access Request plugin on your cluster; the flow works without it).
 7. **Bob's session gains prod** — `tsh ls` now shows `prod-ssh-0`; `tsh ssh ec2-user@prod-ssh-0`.
@@ -80,6 +80,10 @@ Allow 3–5 minutes after `apply` for instances to boot and register (`tsh ls`, 
 | `ssh_dev_count` | Dev SSH node count | `2` |
 | `create_demo_rbac` | Demo roles + local demo user | `true` |
 | `demo_user_name` | Local demo user name | `"bob"` |
+| `extra_demo_user_names` | Extra demo users (one persona per demo workstation) | `[]` |
+| `demo_rbac_role_prefix` | Role-name prefix; `""` = canonical unprefixed names (dedicated clusters) | your username |
+| `auto_approve_reason` | Exact request reason that policy-approves `staging-access` requests | `null` (off) |
+| `request_max_duration` | Max JIT window for approved access requests | `1h` |
 | `env` / `prod_env` / `team` | Labels driving RBAC | `dev` / `prod` / `platform` |
 | `region` | AWS region | `us-east-2` |
 | `create_nat_gateway` | Private subnet + NAT (~$1/day) | `false` |

--- a/templates/teleport-terraform/profiles/main.tf
+++ b/templates/teleport-terraform/profiles/main.tf
@@ -24,8 +24,8 @@ terraform {
       version = "~> 5.99"
     }
     teleport = {
-      source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = "~> 18.0"
+      source  = "terraform-staging.releases.development.teleport.dev/gravitational/teleport"
+      version = "19.0.0-dev.terraform.3"
     }
     random = {
       source  = "hashicorp/random"
@@ -81,6 +81,21 @@ data "aws_ami" "linux" {
   }
 }
 
+# Ubuntu for the Linux desktop host — AL2023 ships no desktop environment
+# packages, so the shared AL2023 AMI can't back linux_desktop_service.
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 data "aws_ami" "windows_server" {
   most_recent = true
   owners      = ["amazon"]
@@ -125,11 +140,19 @@ module "demo_rbac" {
   count  = var.create_demo_rbac ? 1 : 0
   source = "../modules/demo-rbac"
 
-  name_prefix    = local.user_prefix
-  env            = var.env
-  prod_env       = var.enable_ssh_prod ? var.prod_env : null
-  team           = var.team
-  demo_user_name = var.demo_user_name
+  name_prefix           = var.demo_rbac_role_prefix != null ? var.demo_rbac_role_prefix : local.user_prefix
+  env                   = var.env
+  prod_env              = var.enable_ssh_prod ? var.prod_env : null
+  team                  = var.team
+  demo_user_name        = var.demo_user_name
+  extra_demo_user_names = var.extra_demo_user_names
+  auto_approve_reason   = var.auto_approve_reason
+  request_max_duration  = var.request_max_duration
+  mcp_tools             = var.mcp_tools
+  mcp_rw_app            = var.enable_mcp ? "mcp-filesystem" : null
+  # The linux-desktop role lives in modules/linux-desktop (needs the v19
+  # provider); demo-rbac just attaches it to the demo personas.
+  extra_role_names = var.enable_linux_desktop ? [module.linux_desktop[0].access_role_name] : []
 }
 
 # ---------------------------------------------------------------------------
@@ -496,6 +519,37 @@ module "desktop_service" {
 }
 
 # ---------------------------------------------------------------------------
+# Desktop Access: Linux desktop (Teleport 19+) — Xfce over Xvfb, rendered in
+# the browser. The service runs on the desktop host itself; the module also
+# owns the linux-desktop-access role (linux_desktop_* role fields need the
+# v19 provider, which demo-rbac's 18.x pin can't express).
+# ---------------------------------------------------------------------------
+module "linux_desktop" {
+  count  = var.enable_linux_desktop ? 1 : 0
+  source = "../modules/linux-desktop"
+
+  env           = var.env
+  team          = var.team
+  user          = var.user
+  proxy_address = var.proxy_address
+  ami_id        = data.aws_ami.ubuntu.id
+  instance_type = "t3.medium"
+  tags          = local.resource_tags
+
+  subnet_id          = module.network.subnet_id
+  security_group_ids = [module.network.security_group_id]
+
+  # Personas first (created on the host — the service can't create users),
+  # ubuntu as the generic fallback login.
+  desktop_logins = concat(
+    var.create_demo_rbac ? concat([var.demo_user_name], var.extra_demo_user_names) : [],
+    ["ubuntu"]
+  )
+  create_access_role = var.create_demo_rbac
+  name_prefix        = var.demo_rbac_role_prefix != null ? var.demo_rbac_role_prefix : local.user_prefix
+}
+
+# ---------------------------------------------------------------------------
 # Machine ID: MCP stdio bot (AI/Claude access with audit + RBAC).
 # ---------------------------------------------------------------------------
 resource "random_string" "bot_suffix" {
@@ -531,6 +585,7 @@ module "mcp_registration" {
   labels = {
     env                              = var.env
     team                             = var.team
+    "teleport.dev/app"               = "mcp-filesystem"
     "teleport.internal/app-sub-kind" = "mcp"
   }
   mcp_command          = "docker"

--- a/templates/teleport-terraform/profiles/outputs.tf
+++ b/templates/teleport-terraform/profiles/outputs.tf
@@ -21,10 +21,15 @@ output "connection_guide" {
     %{~if var.enable_ssh_prod}
 
     Access request demo (prod node is invisible until approved):
-       tsh request create --roles=${var.create_demo_rbac ? "${local.user_prefix}-prod-readonly" : "prod-readonly-access"} --reason="check prod logs"
+       tsh request create --roles=${try(module.demo_rbac[0].prod_access_role, "prod-readonly-access")} --reason="check prod logs"
        # approver: tsh request review <request-id> --approve --reason="ok"
        # then: tsh ls shows ${var.prod_env}-ssh-0
        tsh ssh ec2-user@${var.prod_env}-ssh-0
+    %{~endif}
+    %{~if var.enable_ssh_prod && var.create_demo_rbac && var.auto_approve_reason != null}
+
+    Staging elevation (approved by policy in seconds, no human reviewer):
+       tsh request create --roles=${try(module.demo_rbac[0].staging_access_role, "")} --reason="${var.auto_approve_reason}"
     %{~endif}
     %{~if var.enable_postgres || var.enable_mysql || var.enable_mongodb || var.enable_cassandra || var.enable_rds_mysql}
 
@@ -79,6 +84,14 @@ output "connection_guide" {
 
     Windows Desktop (web UI only):
        https://${var.proxy_address}/web/desktops
+    %{~endif}
+    %{~if var.enable_linux_desktop}
+
+    Linux Desktop (web UI only):
+       https://${var.proxy_address}/web/desktops
+       # ${var.env}-linux-desktop → Connect → pick a login (${var.create_demo_rbac ? "${var.demo_user_name} or " : ""}ubuntu)
+       # allow ~5 min after apply: Xfce is a few GB of packages
+       tsh ssh ubuntu@${var.env}-linux-desktop   # debug path onto the host
     %{~endif}
 
     Audit trail:

--- a/templates/teleport-terraform/profiles/presets/ansible.tfvars
+++ b/templates/teleport-terraform/profiles/presets/ansible.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: ansible only.
+profile_label = "ansible"
+
+enable_ansible = true

--- a/templates/teleport-terraform/profiles/presets/aws-console.tfvars
+++ b/templates/teleport-terraform/profiles/presets/aws-console.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: aws-console only.
+profile_label = "aws-console"
+
+enable_aws_console = true

--- a/templates/teleport-terraform/profiles/presets/cassandra.tfvars
+++ b/templates/teleport-terraform/profiles/presets/cassandra.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: cassandra only.
+profile_label = "cassandra"
+
+enable_cassandra = true

--- a/templates/teleport-terraform/profiles/presets/cloud-native-apps.tfvars
+++ b/templates/teleport-terraform/profiles/presets/cloud-native-apps.tfvars
@@ -1,0 +1,7 @@
+# Modern cloud shop — internal tools + RDS IAM auth + AWS Console RBAC. ~$3-5/day.
+profile_label = "cloud-native-apps"
+
+enable_grafana     = true
+enable_httpbin     = true
+enable_rds_mysql   = true
+enable_aws_console = true

--- a/templates/teleport-terraform/profiles/presets/conference.tfvars
+++ b/templates/teleport-terraform/profiles/presets/conference.tfvars
@@ -1,0 +1,77 @@
+# presets/conference.tfvars
+#
+# Conference booth backend. Self-contained: stands up its own data-plane
+# resources AND its own demo RBAC (modules/demo-rbac) plus local demo
+# personas. It does not depend on the cluster's existing roles.
+# Companion runbook: docs/conference-event-runbook.md (build checklist,
+# morning pre-flight, teardown order).
+#
+# Covers the three demo tracks' Show sections:
+#   Track A (Attack Surface)  -> SSH, Database, Access Requests
+#   Track B (Audit/Detection) -> SSH, Database, Access Graph*, MCP audit beat
+#   Track C (ZSP + Graph)     -> SSH login, Access Requests, Access Graph*
+#
+# * Access Graph is a cluster-level feature, not stood up by this preset —
+#   enable it on the event cluster's control plane.
+#
+# Deploy:
+#   tsh login --proxy=<event-cluster> --auth=<connector>
+#   eval $(tctl terraform env)
+#   export TF_VAR_proxy_address=<event-cluster>
+#   export TF_VAR_user=<you>@goteleport.com    # deployer email -> tags
+#   cd profiles
+#   terraform init
+#   terraform apply -var-file=presets/conference.tfvars
+#
+# After apply, read the two outputs you need at the booth:
+#   terraform output connection_guide   # exact tsh commands for what's deployed
+#   terraform output demo_user_setup    # one-time persona activation + reviewer grant
+#
+# Destroy: FOLLOW THE TEARDOWN RUNBOOK in docs/conference-event-runbook.md
+# (strip role holders and connector mappings first), then:
+#   terraform destroy -var-file=presets/conference.tfvars
+
+profile_label = "conference" # set per event (e.g. "kubecon-2027") -> resource tags
+
+# --- Server Access ---
+enable_ssh      = true # dev-ssh-0, dev-ssh-1  (Section 2)
+enable_ssh_prod = true # prod-ssh-0, invisible until an access request is approved
+#                      # also creates the JIT role trio + demo-requester/demo-reviewer (Section 6)
+
+# --- Demo RBAC: canonical (unprefixed) role names for the published playbook ---
+# Roles: dev-access, staging-access, prod-access, prod-access-mfa,
+#        demo-requester, demo-reviewer. prod-access-mfa enforces per-session
+#        webauthn MFA (hardware-key policy would require YubiKeys at the booth).
+demo_rbac_role_prefix = ""
+auto_approve_reason   = "authorized job" # staging-access requests with exactly this reason auto-approve
+request_max_duration  = "168h"           # playbook: requests up to 7 days
+extra_demo_user_names = ["alice"]        # station 2 persona — one demo user per workstation
+#                                        # (shared personas collide: tctl lock --user=X kills BOTH stations)
+
+# --- Database Access ---
+enable_postgres = true # postgres-dev, cert auth, no passwords  (Section 4)
+
+# --- Application Access ---
+enable_demo_panel = true # demo-panel-dev, Flask panel showing the JWT identity claims
+enable_grafana    = true # grafana-dev, JWT auto-login — a real app consuming the same
+#                        # Teleport-Jwt-Assertion the demo panel visualizes
+
+# --- Desktop Access ---
+enable_windows = true # Windows Server + desktop service; browser RDP, per-identity
+#                     # local users created on the fly (no shared Administrator password).
+#                     # Web UI only — no tsh command. Allow ~10-15 min to boot + register.
+
+# --- Machine / Non-Human Identity ---
+enable_mcp = true # mcp-filesystem-dev + bot (Track B NHI/AI beat)
+# Read-only MCP tool allowlist on dev-access. Teleport FILTERS denied tools out
+# of tools/list (an AI client is never offered write_file), and direct calls to
+# unlisted tools are denied and audited (mcp.session.request, success=false).
+# Demo it with MCP Inspector, not an AI app — see the guide's Section 8.
+mcp_tools      = ["read_*", "list_*", "search_files", "get_file_info", "directory_tree"]
+enable_ansible = true # dev-ansible + bot, cert-based automation, no static keys (Track A story)
+
+# --- Defaults left as-is ---
+# create_demo_rbac = true  (self-contained roles + local personas)
+# env / prod_env / team    = dev / prod / platform
+# ssh_dev_count            = 2
+# create_nat_gateway       = false  (public subnet, inbound blocked by SG; keep for booth)

--- a/templates/teleport-terraform/profiles/presets/demo-panel.tfvars
+++ b/templates/teleport-terraform/profiles/presets/demo-panel.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: demo-panel only.
+profile_label = "demo-panel"
+
+enable_demo_panel = true

--- a/templates/teleport-terraform/profiles/presets/dev-demo.tfvars
+++ b/templates/teleport-terraform/profiles/presets/dev-demo.tfvars
@@ -1,0 +1,13 @@
+# Developer "day in the life" — Bob + access requests + session locking.
+# ~$5-7/day. See profiles/README.md for the full demo flow.
+profile_label = "dev-demo"
+
+enable_ssh      = true
+enable_ssh_prod = true
+enable_postgres = true
+enable_mongodb  = true
+enable_grafana  = true
+enable_httpbin  = true
+enable_windows  = true
+enable_mcp      = true
+enable_ansible  = true

--- a/templates/teleport-terraform/profiles/presets/full-platform.tfvars
+++ b/templates/teleport-terraform/profiles/presets/full-platform.tfvars
@@ -1,0 +1,15 @@
+# All-up POC — every major capability in one deployment. ~$8-12/day.
+profile_label = "full-platform"
+
+enable_ssh         = true
+enable_postgres    = true
+enable_mongodb     = true
+enable_rds_mysql   = true
+enable_grafana     = true
+enable_httpbin     = true
+enable_demo_panel  = true
+enable_aws_console = true
+enable_windows     = true
+# Teleport 19+ only — drop this flag on 18.x clusters.
+enable_linux_desktop = true
+enable_mcp           = true

--- a/templates/teleport-terraform/profiles/presets/grafana.tfvars
+++ b/templates/teleport-terraform/profiles/presets/grafana.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: grafana only.
+profile_label = "grafana"
+
+enable_grafana = true

--- a/templates/teleport-terraform/profiles/presets/httpbin.tfvars
+++ b/templates/teleport-terraform/profiles/presets/httpbin.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: httpbin only.
+profile_label = "httpbin"
+
+enable_httpbin = true

--- a/templates/teleport-terraform/profiles/presets/linux-desktop.tfvars
+++ b/templates/teleport-terraform/profiles/presets/linux-desktop.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: linux desktop only (Teleport 19+).
+profile_label = "linux-desktop"
+
+enable_linux_desktop = true

--- a/templates/teleport-terraform/profiles/presets/mcp.tfvars
+++ b/templates/teleport-terraform/profiles/presets/mcp.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: mcp only.
+profile_label = "mcp"
+
+enable_mcp = true

--- a/templates/teleport-terraform/profiles/presets/mongodb.tfvars
+++ b/templates/teleport-terraform/profiles/presets/mongodb.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: mongodb only.
+profile_label = "mongodb"
+
+enable_mongodb = true

--- a/templates/teleport-terraform/profiles/presets/mysql.tfvars
+++ b/templates/teleport-terraform/profiles/presets/mysql.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: mysql only.
+profile_label = "mysql"
+
+enable_mysql = true

--- a/templates/teleport-terraform/profiles/presets/postgres.tfvars
+++ b/templates/teleport-terraform/profiles/presets/postgres.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: postgres only.
+profile_label = "postgres"
+
+enable_postgres = true

--- a/templates/teleport-terraform/profiles/presets/rds-mysql.tfvars
+++ b/templates/teleport-terraform/profiles/presets/rds-mysql.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: rds-mysql only.
+profile_label = "rds-mysql"
+
+enable_rds_mysql = true

--- a/templates/teleport-terraform/profiles/presets/ssh.tfvars
+++ b/templates/teleport-terraform/profiles/presets/ssh.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: ssh only.
+profile_label = "ssh"
+
+enable_ssh = true

--- a/templates/teleport-terraform/profiles/presets/windows.tfvars
+++ b/templates/teleport-terraform/profiles/presets/windows.tfvars
@@ -1,0 +1,4 @@
+# Single-feature demo: windows only.
+profile_label = "windows"
+
+enable_windows = true

--- a/templates/teleport-terraform/profiles/variables.tf
+++ b/templates/teleport-terraform/profiles/variables.tf
@@ -119,6 +119,12 @@ variable "enable_windows" {
   default     = false
 }
 
+variable "enable_linux_desktop" {
+  description = "Linux desktop host (Ubuntu + Xfce over Xvfb, browser-based). Requires Teleport 19+ and the v19 provider."
+  type        = bool
+  default     = false
+}
+
 variable "enable_mcp" {
   description = "MCP stdio server + Machine ID bot (AI/Claude access, read-only tools)"
   type        = bool
@@ -167,6 +173,36 @@ variable "demo_user_name" {
   description = "Name of the local demo user (developer persona). Usernames are cluster-global — override on shared clusters."
   type        = string
   default     = "bob"
+}
+
+variable "extra_demo_user_names" {
+  description = "Additional local demo users (same roles as demo_user_name) — one persona per demo workstation so concurrent demos don't collide."
+  type        = list(string)
+  default     = []
+}
+
+variable "demo_rbac_role_prefix" {
+  description = "Role-name prefix for the demo RBAC. Default (null) uses your username so concurrent SEs don't collide. Set to \"\" on a dedicated cluster for the canonical unprefixed names (dev-access, staging-access, prod-access, prod-access-mfa)."
+  type        = string
+  default     = null
+}
+
+variable "auto_approve_reason" {
+  description = "When set, staging-access requests whose reason contains this phrase are auto-approved by policy (access_monitoring_rule, builtin integration). Requires enable_ssh_prod + create_demo_rbac."
+  type        = string
+  default     = null
+}
+
+variable "request_max_duration" {
+  description = "Maximum duration of an approved access request (JIT window)"
+  type        = string
+  default     = "1h"
+}
+
+variable "mcp_tools" {
+  description = "MCP tool allowlist for the demo dev role (glob patterns). Default allows all tools."
+  type        = list(string)
+  default     = ["*"]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A show-agnostic conference booth preset (`profiles/presets/conference.tfvars`) and the demo-rbac capabilities it depends on. One preset stands up the full booth data plane: SSH dev/prod, postgres, JWT apps (demo panel + Grafana), MCP, Ansible, Windows, plus self-contained demo RBAC and personas.

- demo-rbac: canonical unprefixed role names for published playbooks (`demo_rbac_role_prefix = ""`), JIT trio (staging/prod/prod-mfa) with an auto-approve access_monitoring_rule (exact-match reason), MCP tool allowlist plus an optional `<app>-rw` contrast role, persona `windows_logins` traits (RDP as the persona, not a shared login), extra personas per station, corrected create_host_user_mode enum values.
- Event presets are now tracked: gitignore exception `!profiles/presets/*.tfvars` (they are shared, credential-free config; the blanket `*.tfvars` rule silently hid them).
- Includes the linux-desktop module (Teleport 19+, behind `enable_linux_desktop`) because `profiles/main.tf` wires it.

Companion runbook and booth tooling are in a separate PR to keep this one focused.

## What changed
- [ ] New use case
- [ ] New POC
- [x] New template
- [ ] New integration
- [ ] Docs only

New preset + update to `templates/teleport-terraform` profiles/demo-rbac.

## How to test
```
tsh login --proxy=<cluster>
eval $(tctl terraform env)
export TF_VAR_proxy_address=<cluster> TF_VAR_user=<you>@goteleport.com
cd templates/teleport-terraform/profiles
terraform init && terraform apply -var-file=presets/conference.tfvars
terraform output connection_guide
```
Then as the demo persona: `tsh request create --roles=staging-access --reason="authorized job"` auto-approves in seconds; any other reason stays PENDING.

## Checklist
- [x] README included (profiles/ and modules/demo-rbac READMEs updated)
- [x] .env.example (n/a; the preset itself is the example config, no secrets)
- [x] Requested reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
