### PR TITLE
feat(templates): conference booth tooling + event runbook

### DIFF
--- a/templates/teleport-terraform/README.md
+++ b/templates/teleport-terraform/README.md
@@ -39,7 +39,7 @@ terraform apply -var-file=presets/dev-demo.tfvars   # or any preset — see prof
 
 ### Profiles (start here)
 
-One composable root; a preset per demo. Archetypes: `dev-demo` (~$5–7/day), `full-platform` (~$8–12/day), `cloud-native-apps` (~$3–5/day). Single-feature presets: `ssh`, `postgres`, `mysql`, `mongodb`, `cassandra`, `rds-mysql`, `grafana`, `httpbin`, `demo-panel`, `aws-console`, `windows`, `mcp`, `ansible`.
+One composable root; a preset per demo. Archetypes: `dev-demo` (~$5–7/day), `full-platform` (~$8–12/day), `cloud-native-apps` (~$3–5/day). Single-feature presets: `ssh`, `postgres`, `mysql`, `mongodb`, `cassandra`, `rds-mysql`, `grafana`, `httpbin`, `demo-panel`, `aws-console`, `windows`, `linux-desktop` (Teleport 19+), `mcp`, `ansible`.
 
 See [profiles/README.md](profiles/README.md) for usage, the preset table, demo RBAC (Bob), and the dev-demo talk track.
 
@@ -73,6 +73,7 @@ The EKS control plane (Slack plugin, SCIM, Access Graph) and the proxy-peer vari
 | `ssh-node` | EC2 instances running Teleport SSH service with dynamic host user creation. |
 | `windows-instance` | Windows Server 2022 host pre-configured for Teleport Desktop Access. |
 | `desktop-service` | Linux host running `windows_desktop_service` — RDP proxy with full session recording. |
+| `linux-desktop` | Ubuntu host running `linux_desktop_service` (Teleport 19+) — Xfce over Xvfb, browser-based, session recording. Owns its own access role (needs the v19 provider). |
 
 ### Database
 

--- a/templates/teleport-terraform/docs/conference-event-runbook.md
+++ b/templates/teleport-terraform/docs/conference-event-runbook.md
@@ -1,0 +1,62 @@
+# Conference Event Runbook
+
+How to stand up, run, and tear down a booth demo environment built from
+`profiles/presets/conference.tfvars`. Every item here was learned the hard way
+at a live event; the fixes that could live in code are in this repo already.
+
+## Build (before the event)
+
+- Deploy from the preset. Set `profile_label` per event (resource tags), then:
+  `tsh login --proxy=<event-cluster>`, `eval $(tctl terraform env)`,
+  `terraform apply -var-file=presets/conference.tfvars`. Read the
+  `connection_guide` and `demo_user_setup` outputs.
+- Commit preset changes the day you make them. Presets are tracked
+  (`!profiles/presets/*.tfvars`); do not let event config live on one laptop.
+- Keep terraform state off the laptop: remote backend in the event's region,
+  or at minimum a daily copy.
+- Land ALL SSO connector role-mapping changes at build time, not mid-event.
+  They live with the control-plane owner and need review lead time.
+- Demo personas: one per station (a `tctl lock --user` is cluster-wide, so a
+  shared persona kills both stations). Enroll each persona's MFA on its own
+  station hardware, early. Keep the cluster at `second_factor: on` (webauthn
+  preferred, TOTP allowed) so rehearsal in a VM stays possible.
+- Build booth Macs with `tools/demo-mac-setup/`. Rehearse the build on a
+  factory-fresh macOS VM first; a clean-slate run catches bugs a lived-in
+  machine hides.
+- Official signed tsh only on demo machines: Device Trust and hardware-key
+  webauthn reject community builds (setup.sh installs the pkg).
+
+## Every morning
+
+```
+PROXY=<event-cluster> ./tools/conference-preflight.sh
+```
+
+Zero FAILs before the first demo. The script does a live request cycle,
+checks one-app-server-per-app, probes the MCP allowlist end to end, and
+sweeps stale locks left by rehearsals.
+
+## During the event
+
+- Check every `terraform plan` for replacements before applying. Instance
+  modules pin the AMI (`ignore_changes`), but the habit stays: an upstream
+  AMI bump must never replace a healthy fleet mid-event.
+- Never live-edit an agent's teleport.yaml over its own tunnel. Replace
+  stateless nodes with `terraform apply -replace=...` instead.
+- Demo MCP with MCP Inspector, not an AI client. Teleport filters denied
+  tools out of tools/list, so an AI client shows no visible denial; Inspector
+  puts the per-identity toolset difference on one screen.
+
+## Teardown (the order matters)
+
+1. Strip terraform-managed roles from any NON-terraform users that hold them
+   (`tctl users update --set-roles ...`), or role deletion fails with
+   "role is still in use by a user".
+2. Remove the demo role names from the SSO connector mappings (control-plane
+   repo PR) and verify with `tctl get saml/<connector>` BEFORE deleting
+   roles. Deleting a role the connector still maps breaks every SSO login
+   with "role not found".
+3. `terraform destroy -var-file=presets/conference.tfvars` for the data plane.
+4. Only then should the control-plane owner delete the cluster and DNS.
+5. If the control plane dies first, the leftovers are orphans:
+   `terraform state rm` them and verify `terraform state list` is empty.

--- a/templates/teleport-terraform/tools/conference-preflight.sh
+++ b/templates/teleport-terraform/tools/conference-preflight.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# conference-preflight.sh — verify an event booth environment (built from
+# profiles/presets/conference.tfvars) as the SSO (SE) user.
+#
+# Run with an active SSO session on the event cluster. Checks the whole booth
+# environment in ~30s: roles, resources, labels, the auto-approve rule (live
+# end-to-end, self-cleaning), DB connectivity, MCP allowlist + tools/list
+# probe, desktop registration, and stale locks from rehearsals.
+#
+#   PROXY=<event-cluster> ./conference-preflight.sh    # full run (includes a real request cycle)
+#   SKIP_REQUEST_TEST=1 PROXY=... ./conference-preflight.sh   # read-only checks only
+#   TELEPORT_AUTH_NS=<ns> enables in-pod tctl cleanup of the test request
+#   (self-hosted control planes in k8s only; otherwise the request just expires)
+#
+# Exit code = number of failed checks. WARNs don't fail the run.
+
+set -uo pipefail
+
+PROXY="${PROXY:?usage: PROXY=<event-cluster> [DEMO_USER=<persona>] $0}"
+DEMO_USER="${DEMO_USER:-bob}"
+PASS=0; FAIL=0; WARN=0
+
+if [ -t 1 ]; then G=$'\033[32m'; R=$'\033[31m'; Y=$'\033[33m'; N=$'\033[0m'; else G=""; R=""; Y=""; N=""; fi
+ok()   { echo "${G}PASS${N}  $1"; PASS=$((PASS+1)); }
+bad()  { echo "${R}FAIL${N}  $1"; FAIL=$((FAIL+1)); }
+warn() { echo "${Y}WARN${N}  $1"; WARN=$((WARN+1)); }
+
+echo "── booth pre-flight: $PROXY ($(date '+%H:%M')) ────────────────────"
+
+# 1. Session: logged in, right proxy, SE roles present
+STATUS=$(tsh status 2>/dev/null)
+if ! grep -q "$PROXY" <<<"$STATUS"; then
+  bad "not logged into $PROXY — run: tsh login --proxy=$PROXY"
+  echo "aborting: everything else needs a session"; exit 1
+fi
+ok "logged into $PROXY ($(grep 'Logged in as:' <<<"$STATUS" | awk '{print $4}'))"
+for role in dev-access demo-requester demo-reviewer; do
+  grep -q "$role" <<<"$STATUS" && ok "cert carries $role" \
+    || bad "cert missing $role — re-login (roles apply at login) or check connector mapping"
+done
+
+# 2. Cluster: Okta is the default auth
+AUTHTYPE=$(curl -s --max-time 5 "https://$PROXY/webapi/ping" | jq -r '.auth.type' 2>/dev/null)
+[ "$AUTHTYPE" = "saml" ] && ok "default login is Okta (auth.type=saml)" \
+  || bad "auth.type=$AUTHTYPE — expected saml; check gitops values"
+
+# 3. SSH nodes present with healthy dynamic labels
+NODES=$(tsh ls 2>/dev/null)
+for n in dev-ssh-0 dev-ssh-1 prod-ssh-0; do
+  grep -q "^$n " <<<"$NODES" && ok "node $n online" || bad "node $n missing from tsh ls"
+done
+BADLBL=$(grep -cE 'disk_used=exit|disk_used=$' <<<"$NODES" || true)
+[ "$BADLBL" -eq 0 ] && ok "dynamic labels healthy (disk_used numeric)" \
+  || bad "$BADLBL node(s) show broken disk_used label"
+
+# 4. Database registered + live connect as writer
+tsh db ls 2>/dev/null | grep -q postgres-dev && ok "postgres-dev registered" || bad "postgres-dev missing"
+DB_OUT=$(echo "SELECT 1;" | tsh db connect postgres-dev --db-user=writer --db-name=postgres 2>&1)
+grep -q "(1 row)" <<<"$DB_OUT" && ok "live psql connect as writer works" \
+  || bad "db connect failed: $(tail -1 <<<"$DB_OUT")"
+
+# 5. Apps registered (JSON — the table output truncates names)
+APPS=$(tsh apps ls --format=json 2>/dev/null | jq -r '.[].metadata.name')
+for app in demo-panel-dev grafana-dev mcp-filesystem-dev; do
+  grep -qx "$app" <<<"$APPS" && ok "$app registered" || bad "$app missing"
+done
+
+# 5a. Each app must be served by exactly its own host. A broad app_service
+# selector on any host claims other apps too, and the proxy then routes
+# sessions to hosts whose upstreams don't exist (intermittent Connection
+# Refused — burned us 2026-07-24).
+PAIRS=$(tctl apps ls --format=json 2>/dev/null | jq -r '[.[] | select(.metadata.name | test("demo-panel-dev|grafana-dev|mcp-filesystem-dev")) | .metadata.name + ":" + (.spec.hostname // "?")] | sort | join(" ")')
+if [ "$PAIRS" = "demo-panel-dev:dev-demo-panel grafana-dev:dev-grafana mcp-filesystem-dev:dev-mcp-filesystem" ]; then
+  ok "each app served by exactly its own host"
+else
+  bad "app-server claims wrong (expect one server per app): $PAIRS"
+fi
+
+# 5b. Per-app subdomain DNS — browser App Access needs the wildcard record
+if [ -n "$(dig +short "demo-panel-dev.$PROXY" 2>/dev/null)" ]; then
+  ok "app subdomain DNS resolves (wildcard record present)"
+else
+  bad "demo-panel-dev.$PROXY does not resolve — wildcard *.$PROXY DNS record missing; browser App Access (Section 5) will fail"
+fi
+
+# 6. Windows desktop registered (singular kind — plural errors)
+DESKTOP=$(tctl get windows_desktop --format=json 2>/dev/null | jq -r '.[].metadata.name' | head -1)
+[ -n "$DESKTOP" ] && ok "windows desktop registered: $DESKTOP" || bad "no windows_desktop registered"
+
+# 7. Demo RBAC objects all present
+ROLES=$(tctl get roles --format=json 2>/dev/null | jq -r '.[].metadata.name')
+for role in dev-access staging-access prod-access prod-access-mfa demo-requester demo-reviewer; do
+  grep -qx "$role" <<<"$ROLES" && ok "role $role exists" || bad "role $role missing"
+done
+for u in bob alice; do
+  tctl get "user/$u" >/dev/null 2>&1 && ok "persona $u exists" || bad "persona $u missing"
+done
+
+# 8. MCP read-only allowlist still on dev-access
+MCP_TOOLS=$(tctl get role/dev-access --format=json 2>/dev/null | jq -c '.[0].spec.allow.mcp.tools')
+if [ "$MCP_TOOLS" = '["read_*","list_*","search_files","get_file_info","directory_tree"]' ]; then
+  ok "dev-access MCP allowlist is read-only"
+else
+  bad "dev-access MCP tools = $MCP_TOOLS — Inspector contrast beat will not fire"
+fi
+
+# 8a. Inspector contrast beat: rw role exists and the SE cert carries it.
+# Teleport filters denied tools out of tools/list, so the demo is List Tools
+# as SE (full toolset via mcp-filesystem-rw) vs as bob (read-only allowlist).
+RW_TOOLS=$(tctl get role/mcp-filesystem-rw --format=json 2>/dev/null | jq -c '.[0].spec.allow.mcp.tools')
+[ "$RW_TOOLS" = '["*"]' ] && ok "mcp-filesystem-rw role present (all tools)" \
+  || bad "mcp-filesystem-rw role missing or wrong (tools=$RW_TOOLS)"
+grep -q "mcp-filesystem-rw" <<<"$STATUS" && ok "cert carries mcp-filesystem-rw (SE side of the contrast)" \
+  || bad "cert missing mcp-filesystem-rw — add it to the okta connector mapping (gitops) and re-login; until then SEs see the same read-only list as bob"
+
+# 8b. Live MCP probe: drive a real stdio session and check what tools/list
+# actually offers this cert. Expectation flips with the rw role.
+MCP_LIST=$({ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"preflight","version":"1.0"}}}'; sleep 4; printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'; sleep 4; } | tsh mcp connect mcp-filesystem-dev 2>/dev/null | jq -r 'select(.id==2) | [.result.tools[].name] | join(",")')
+if [ -z "$MCP_LIST" ]; then
+  bad "MCP live probe returned no tools — session failed (check dev-mcp-filesystem / docker)"
+elif grep -q "mcp-filesystem-rw" <<<"$STATUS"; then
+  grep -q "write_file" <<<"$MCP_LIST" && ok "MCP probe: full toolset offered (rw cert)" \
+    || bad "MCP probe: rw role on cert but write_file not offered: $MCP_LIST"
+else
+  grep -q "write_file" <<<"$MCP_LIST" && bad "MCP probe: write_file offered WITHOUT the rw role: $MCP_LIST" \
+    || ok "MCP probe: read-only filtering enforced (write_file absent from tools/list)"
+fi
+
+# 9. Auto-approve rule exists + AI summary model configured
+tctl get access_monitoring_rule/demo-auto-approve-staging >/dev/null 2>&1 \
+  && ok "auto-approve rule present" || bad "access_monitoring_rule demo-auto-approve-staging missing"
+tctl get inference_model --format=json 2>/dev/null | jq -r '.[].metadata.name' | grep -q bedrock \
+  && ok "AI session-summary model configured" || warn "no inference_model found — AI summary beat unavailable"
+
+# 10. No stale locks on the personas (left over from lock-beat rehearsals)
+LOCKS=$(tctl get locks --format=json 2>/dev/null | jq -r '.[].spec.target.user // empty')
+if grep -qE "^(bob|alice)$" <<<"$LOCKS"; then
+  bad "stale lock on a demo persona — tctl get locks, then tctl rm lock/<name>"
+else
+  ok "no stale locks on demo personas"
+fi
+
+# 11. Live auto-approval cycle (creates a real request as $DEMO_USER, then deletes it)
+if [ "${SKIP_REQUEST_TEST:-0}" != "1" ]; then
+  REQ=$(tctl request create "$DEMO_USER" --roles=staging-access --reason="authorized job" 2>/dev/null)
+  if [ -z "$REQ" ]; then
+    bad "could not create test request as $DEMO_USER"
+  else
+    STATE=""
+    for _ in 1 2 3 4 5 6; do
+      sleep 3
+      # tsh request show works for reviewers; tctl request ls is scoped and shows nothing
+      STATE=$(tsh request show "$REQ" 2>/dev/null | awk '/^Status:/ {print $2}')
+      [ "$STATE" = "APPROVED" ] && break
+    done
+    [ "$STATE" = "APPROVED" ] && ok "auto-approval fired (request $REQ APPROVED)" \
+      || bad "auto-approval did not fire within 18s (state: ${STATE:-not visible})"
+    # Deleting requests needs local-admin tctl: exec into the auth pod if the
+    # control plane is self-hosted in k8s (set TELEPORT_AUTH_NS to enable).
+    if [ -n "${TELEPORT_AUTH_NS:-}" ]; then
+      tsh kube login "$PROXY" >/dev/null 2>&1
+      AUTHPOD=$(tsh kubectl get pods -n "$TELEPORT_AUTH_NS" -l app.kubernetes.io/component=auth -o name 2>/dev/null | head -1)
+      if [ -n "$AUTHPOD" ] && tsh kubectl exec -n "$TELEPORT_AUTH_NS" "${AUTHPOD#pod/}" -- tctl request rm --force "$REQ" >/dev/null 2>&1; then
+        ok "test request cleaned up"
+      else
+        warn "could not delete test request $REQ — it expires on its own, but remove via in-pod tctl for a clean Access Requests view"
+      fi
+    else
+      warn "test request $REQ left to expire (set TELEPORT_AUTH_NS for in-pod tctl cleanup)"
+    fi
+  fi
+else
+  warn "request cycle skipped (SKIP_REQUEST_TEST=1)"
+fi
+
+echo "───────────────────────────────────────────────────────────────"
+echo "  $PASS passed, $FAIL failed, $WARN warnings"
+[ "$FAIL" -eq 0 ] && echo "  Booth is GO." || echo "  Fix the FAILs before the first demo."
+exit "$FAIL"

--- a/templates/teleport-terraform/tools/demo-mac-setup/Brewfile
+++ b/templates/teleport-terraform/tools/demo-mac-setup/Brewfile
@@ -1,0 +1,33 @@
+# Teleport demo Mac setup (booth Mac Minis / SE demo laptops)
+# Install:  brew bundle --file=Brewfile
+# All cask/formula names verified against Homebrew 2026-07-25.
+#
+# Deliberately absent: the "teleport" formula. Device Trust and hardware-key
+# webauthn need the signed tsh from the official pkg (or Teleport Connect,
+# which bundles it): https://goteleport.com/download/
+# Verify after install:  codesign -dv "$(command -v tsh)"  -> TeamIdentifier=QH8AA5B8UP
+
+# GUI apps
+cask "teleport-connect"
+cask "iterm2"                 # team alternatives: "warp", "ghostty"
+cask "visual-studio-code"
+cask "claude"                 # Claude Desktop ("claude-desktop" is not a cask)
+cask "claude-code"
+cask "google-chrome"          # persona Chrome profiles (playbook conventions); skip on MDM-managed Macs
+cask "rectangle"              # skip on MDM-managed Macs (often root-owned already)
+cask "pgadmin4"
+cask "dbeaver-community"
+cask "gcloud-cli"             # gcloud ("google-cloud-sdk" is the deprecated name)
+
+# CLI tools
+brew "kubernetes-cli"         # kubectl (tsh also embeds one: `tsh kubectl`)
+brew "k9s"
+brew "helm"
+brew "libpq", link: true      # psql without a local postgres server
+brew "mysql-client", link: true # mysql CLI without a local server (keg-only: needs the link)
+brew "rainfrog"               # postgres TUI
+brew "awscli"
+brew "azure-cli"
+brew "neovim"
+brew "node"                   # MCP Inspector (Section 8): npx @modelcontextprotocol/inspector
+brew "jq"                     # required by tools/conference-preflight.sh

--- a/templates/teleport-terraform/tools/demo-mac-setup/README.md
+++ b/templates/teleport-terraform/tools/demo-mac-setup/README.md
@@ -1,0 +1,48 @@
+# Demo Mac Setup
+
+Builds a conference demo Mac (booth Mac Mini or SE laptop) from factory-fresh
+macOS to fully provisioned demo station in one unattended run. Proven on a
+factory-fresh macOS VM (see `docs/conference-event-runbook.md`).
+
+## Audience and prerequisites
+
+- Anyone setting up demo machines for an event. No prior state needed: the
+  script installs Homebrew (and Xcode CLT) itself on a clean machine.
+- macOS on Apple Silicon, an admin account, network access.
+
+## Run
+
+```bash
+./setup.sh
+```
+
+Unattended runs (CI, ssh with passwordless sudo): `NONINTERACTIVE=1 ./setup.sh`.
+
+Expected finish: a `BUILD VERIFICATION` block listing every tool as `OK`
+("Build verification: all present."), followed by the per-station manual steps
+(persona Chrome/iTerm profiles, YubiKey enrollment, bookmarks).
+
+## What it installs
+
+- `Brewfile`: GUI apps (Teleport Connect, iTerm2, VS Code, Claude, Chrome,
+  pgAdmin, DBeaver, ...) and CLIs (kubectl, k9s, helm, psql, mysql, cloud
+  CLIs, node, jq).
+- Official signed Teleport client pkg (tsh + tctl). Deliberately NOT from
+  brew: Device Trust and hardware-key webauthn reject community builds. Pin
+  `TELEPORT_VERSION` in setup.sh to your cluster's version.
+- MCP Inspector, pre-cached for the MCP demo (conference Wi-Fi is not your
+  friend).
+
+## Troubleshooting
+
+- A tool shows MISSING in verification: re-run `brew bundle --file=Brewfile`
+  and read its error; keg-only formulas need the `link: true` already set in
+  the Brewfile.
+- `tsh is not the official signed build`: install the pkg from
+  https://goteleport.com/download/ — do not `brew install teleport`.
+- On MDM-managed corporate Macs, Chrome/Rectangle may be root-owned by the
+  MDM; remove those casks from the Brewfile there (booth machines keep them).
+
+## Owners
+
+Revenue Engineering (see repo CODEOWNERS / #rev-tech).

--- a/templates/teleport-terraform/tools/demo-mac-setup/setup.sh
+++ b/templates/teleport-terraform/tools/demo-mac-setup/setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Demo Mac setup: software plus the demo-specific pieces brew can't do.
+# Mirrors the per-station prep in docs/conference-event-runbook.md. Run as the demo
+# user; no sudo needed except what the Homebrew installer itself asks for.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+# Non-login shells (ssh one-liners, some automation) miss these; the Teleport
+# pkg installs to /usr/local/bin and brew to /opt/homebrew/bin.
+export PATH="/usr/local/bin:/opt/homebrew/bin:${PATH}"
+
+# --- 1. Homebrew + packages ---
+if ! command -v brew >/dev/null 2>&1; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+brew update
+brew bundle --file=Brewfile
+
+# --- 2. Teleport client tools (tsh, tctl) ---
+# Deliberately NOT from brew: Device Trust and hardware-key webauthn require
+# Teleport's signed build. Match the cluster's major version.
+TELEPORT_VERSION="18.10.0"
+if ! command -v tsh >/dev/null 2>&1; then
+  echo "Installing official Teleport client pkg ${TELEPORT_VERSION} (sudo will prompt)..."
+  curl -fsSLo "/tmp/teleport-${TELEPORT_VERSION}.pkg" "https://cdn.teleport.dev/teleport-${TELEPORT_VERSION}.pkg"
+  sudo installer -pkg "/tmp/teleport-${TELEPORT_VERSION}.pkg" -target /
+  rm -f "/tmp/teleport-${TELEPORT_VERSION}.pkg"
+fi
+if ! codesign -dv "$(command -v tsh)" 2>&1 | grep -q QH8AA5B8UP; then
+  echo "!! tsh is not the official signed build."
+  echo "   Install the macOS pkg from https://goteleport.com/download/ (or use Teleport Connect's bundled tsh)."
+fi
+
+# --- 3. Pre-cache MCP Inspector (Section 8; conference Wi-Fi is not your friend) ---
+npm install -g @modelcontextprotocol/inspector
+
+# --- 4. Verify the build ---
+echo "--- BUILD VERIFICATION ---"
+MISSING=0
+for c in tsh tctl kubectl k9s helm psql mysql aws az gcloud nvim node jq claude; do
+  if command -v "$c" >/dev/null 2>&1; then
+    printf 'OK       %-8s %s\n' "$c" "$(command -v "$c")"
+  else
+    printf 'MISSING  %s\n' "$c"; MISSING=$((MISSING+1))
+  fi
+done
+npm ls -g --depth=0 2>/dev/null | grep -q '@modelcontextprotocol/inspector' \
+  && echo "OK       mcp-inspector (cached)" || { echo "MISSING  mcp-inspector"; MISSING=$((MISSING+1)); }
+[ "$MISSING" -eq 0 ] && echo "Build verification: all present." || echo "Build verification: $MISSING missing — fix before imaging this machine."
+
+# --- 5. Manual steps ---
+cat <<'EOF'
+--- MANUAL STEPS (per station) ---
+1. Chrome profile for the station's persona (station 1: bob, station 2: alice).
+2. iTerm profile named after the persona; Profiles > Send text at start:
+     export TELEPORT_HOME=$HOME/.tsh-bob        (station 2: .tsh-alice)
+   Give it a distinct color so nobody demos as the wrong identity.
+3. Activate the persona ON THIS MACHINE with its own YubiKey:
+     tctl users reset bob
+   Open the link in the persona's Chrome profile: set password, add hardware key.
+4. Bookmark the event cluster's Web UI in both Chrome profiles
+   (plus the backup environment's, if the event has one).
+5. Wallpaper, cursor, and login password per the must-haves doc.
+EOF


### PR DESCRIPTION
## Summary
Show-agnostic booth tooling for events run from the conference preset, plus the event runbook.

- `tools/conference-preflight.sh`: 34 morning-of checks (roles, resources, labels, live auto-approve request cycle, one-app-server-per-app guard, MCP tools/list probe, stale-lock sweep). `PROXY=<event-cluster>` per event; exit code = failed checks.
- `tools/demo-mac-setup/`: Brewfile + setup.sh building a demo Mac from factory-fresh macOS unattended, ending in a self-verification report. Installs the official signed Teleport pkg (Device Trust rejects brew's community build) and pre-caches MCP Inspector.
- `docs/conference-event-runbook.md`: build checklist, morning pre-flight, demo-day rules, and the teardown order (strip role holders and connector mappings before destroying roles).

## What changed
- [ ] New use case
- [ ] New POC
- [x] New template
- [ ] New integration
- [ ] Docs only

New tooling + docs under `templates/teleport-terraform`.

## How to test
- `PROXY=<cluster> ./tools/conference-preflight.sh` against a conference-preset deployment: all PASS.
- `bash tools/demo-mac-setup/setup.sh` on a clean Mac or macOS VM: ends with "Build verification: all present."

## Checklist
- [x] README included (tools/demo-mac-setup/README.md; runbook is the doc)
- [x] .env.example (n/a)
- [x] Requested reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
